### PR TITLE
make the register_block field optional in the peripherals! macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -765,6 +765,9 @@ pub unsafe trait LessThanOrEqual<RHS> {}
 ///
 /// # Example
 ///
+/// NOTE With device crates generated using svd2rust 0.8+ you can omit the
+/// register_block field.
+///
 /// ``` ignore
 /// #[macro_use]
 /// extern crate cortex_m_rtfm;
@@ -796,6 +799,19 @@ macro_rules! peripherals {
             static $PERIPHERAL:
                 $crate::Peripheral<::$device::$RegisterBlock, $crate::$C> =
                     unsafe { $crate::Peripheral::_new(::$device::$PERIPHERAL) };
+        )+
+    };
+    ($device:ident, {
+        $($PERIPHERAL:ident: Peripheral {
+            ceiling: $C:ident,
+        },)+
+    }) => {
+        $(
+            #[allow(private_no_mangle_statics)]
+            #[no_mangle]
+            static $PERIPHERAL:
+            $crate::Peripheral<::$device::$PERIPHERAL, $crate::$C> =
+                unsafe { $crate::Peripheral::_new(::$device::$PERIPHERAL) };
         )+
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,6 +445,7 @@ pub use cortex_m::asm::{bkpt, wfi};
 pub use cortex_m::peripheral::NVIC as _NVIC;
 
 /// Compiler barrier
+#[cfg(not(thumbv6m))]
 macro_rules! barrier {
     () => {
         asm!(""


### PR DESCRIPTION
with svd2rust 0.8.x peripheral types are written in UPPERCASE and match their
names so specifying the type in the register_block field is no longer necessary.

depends on japaric/svd2rust#85 and a new svd2rust release