### PR TITLE
fix name of interrupt section

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -937,7 +937,7 @@ macro_rules! tasks {
             }
 
             #[allow(dead_code)]
-            #[link_section = ".rodata.interrupts"]
+            #[link_section = ".vector_table.interrupts"]
             #[used]
             static INTERRUPTS: ::$device::interrupt::Handlers =
                 ::$device::interrupt::Handlers {


### PR DESCRIPTION
cortex-m-rt version 3.0 changed the name of the interrupts section to
.vector_table.interrupts. Change cortex-m-rtfm accordingly.