### PR TITLE
Allow initialization of resources in `init`.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,7 +2,7 @@
 runner = 'arm-none-eabi-gdb'
 rustflags = [
   "-C", "link-arg=-Tlink.x",
-  "-C", "linker=arm-none-eabi-ld",
+  "-C", "linker=true",
   "-Z", "linker-flavor=ld",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,10 @@ version = "0.2.1"
 
 [dependencies]
 cortex-m = "0.3.1"
-cortex-m-rtfm-macros = "=0.2.0"
-rtfm-core = "0.1.0"
-static-ref = "0.2.1"
+# TODO should this have been a `path` dep all along?
+cortex-m-rtfm-macros = { path = "macros" }
+# TODO revert before merging
+rtfm-core = { git = "https://github.com/jonas-schievink/rtfm-core.git", branch = "init-resources" }
 
 [target.'cfg(target_arch = "x86_64")'.dev-dependencies]
 compiletest_rs = "0.2.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ version = "0.3.3"
 
 [dev-dependencies.stm32f103xx]
 features = ["rt"]
-version = "0.7.1"
+version = "0.7.5"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,9 @@ version = "0.2.1"
 
 [dependencies]
 cortex-m = "0.3.1"
-# TODO should this have been a `path` dep all along?
+untagged-option = "0.1.1"
+rtfm-core = "0.1.0"
 cortex-m-rtfm-macros = { path = "macros" }
-# TODO revert before merging
-rtfm-core = { git = "https://github.com/jonas-schievink/rtfm-core.git", branch = "init-resources" }
 
 [target.'cfg(target_arch = "x86_64")'.dev-dependencies]
 compiletest_rs = "0.2.8"

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -3,8 +3,8 @@ set -euxo pipefail
 main() {
     case $TARGET in
         thumbv*-none-eabi*)
-            cargo install --list | grep xargo || \
-                cargo install xargo
+            cargo install --list | grep 'xargo v0.3.8' || \
+                cargo install xargo --vers 0.3.8
             rustup component list | grep 'rust-src.*installed' || \
                 rustup component add rust-src
             ;;

--- a/examples/late-resources.rs
+++ b/examples/late-resources.rs
@@ -26,13 +26,24 @@ app! {
         // the initializer. Doing that will require `init` to return the values of all "late"
         // resources.
         static IP_ADDRESS: u32;
+
+        // PORT is used by 2 tasks, making it a shared resource. This just tests another internal
+        // code path and is not important for the example.
+        static PORT: u16;
     },
 
     tasks: {
         SYS_TICK: {
+            priority: 1,
             path: sys_tick,
-            resources: [IP_ADDRESS, ON],
+            resources: [IP_ADDRESS, PORT, ON],
         },
+
+        EXTI0: {
+            priority: 2,
+            path: exti0,
+            resources: [PORT],
+        }
     }
 }
 
@@ -47,6 +58,7 @@ fn init(_p: init::Peripherals, _r: init::Resources) -> init::LateResourceValues 
     init::LateResourceValues {
         // This struct will contain fields for all resources with omitted initializers.
         IP_ADDRESS: ip_address,
+        PORT: 0,
     }
 }
 
@@ -56,6 +68,8 @@ fn sys_tick(_t: &mut Threshold, r: SYS_TICK::Resources) {
 
     r.IP_ADDRESS;
 }
+
+fn exti0(_t: &mut Threshold, _r: EXTI0::Resources) {}
 
 fn idle() -> ! {
     loop {

--- a/examples/late-resources.rs
+++ b/examples/late-resources.rs
@@ -1,0 +1,64 @@
+//! Demonstrates initialization of resources in `init`.
+
+#![deny(unsafe_code)]
+#![feature(proc_macro)]
+#![no_std]
+
+extern crate cortex_m_rtfm as rtfm;
+extern crate stm32f103xx;
+
+use rtfm::{app, Threshold};
+
+app! {
+    device: stm32f103xx,
+
+    resources: {
+        // Usually, resources are initialized with a constant initializer:
+        static ON: bool = false;
+
+        // However, there are cases where this is not possible or not desired. For example, there
+        // may not be a sensible value to use, or the type may not be constructible in a constant
+        // (like `Vec`).
+        // While it is possible to use an `Option` in some cases, that requires you to properly
+        // initialize it and `.unwrap()` it at every use. It also consumes more memory.
+        //
+        // To solve this, it is possible to defer initialization of resources to `init` by omitting
+        // the initializer. Doing that will require `init` to return the values of all "late"
+        // resources.
+        static IP_ADDRESS: u32;
+    },
+
+    tasks: {
+        SYS_TICK: {
+            path: sys_tick,
+            resources: [IP_ADDRESS, ON],
+        },
+    }
+}
+
+// The signature of `init` is now required to have a specific return type.
+fn init(_p: init::Peripherals, _r: init::Resources) -> init::LateResourceValues {
+    // `init::Resources` does not contain `IP_ADDRESS`, since it is not yet initialized.
+    //_r.IP_ADDRESS;     // doesn't compile
+
+    // ...obtain value for IP_ADDRESS from EEPROM/DHCP...
+    let ip_address = 0x7f000001;
+
+    init::LateResourceValues {
+        // This struct will contain fields for all resources with omitted initializers.
+        IP_ADDRESS: ip_address,
+    }
+}
+
+fn sys_tick(_t: &mut Threshold, r: SYS_TICK::Resources) {
+    // Other tasks can access late resources like any other, since they are guaranteed to be
+    // initialized when tasks are run.
+
+    r.IP_ADDRESS;
+}
+
+fn idle() -> ! {
+    loop {
+        rtfm::wfi();
+    }
+}

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -12,7 +12,8 @@ version = "0.2.0"
 [dependencies]
 error-chain = "0.10.0"
 quote = "0.3.15"
-rtfm-syntax = "0.1.0"
+# TODO undo change
+rtfm-syntax = { git = "https://github.com/jonas-schievink/rtfm-syntax.git", branch = "init-resources" }
 syn = "0.11.11"
 
 [lib]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -12,8 +12,7 @@ version = "0.2.0"
 [dependencies]
 error-chain = "0.10.0"
 quote = "0.3.15"
-# TODO undo change
-rtfm-syntax = { git = "https://github.com/jonas-schievink/rtfm-syntax.git", branch = "init-resources" }
+rtfm-syntax = "0.2.0"
 syn = "0.11.11"
 
 [lib]

--- a/macros/src/trans.rs
+++ b/macros/src/trans.rs
@@ -233,7 +233,7 @@ fn init(app: &App, main: &mut Vec<Tokens>, root: &mut Vec<Tokens>) {
             });
 
             late_resources.push(quote! {
-                #_name = #krate::LateResource { init: _late_resources.#name };
+                #_name = #krate::UntaggedOption { some: _late_resources.#name };
             });
         }
 
@@ -344,7 +344,7 @@ fn resources(app: &App, ownerships: &Ownerships, root: &mut Vec<Tokens>) {
                 },
                 None => quote! {
                     // Resource initialized in `init`
-                    static mut #_name: #krate::LateResource<#ty> = #krate::LateResource { uninit: () };
+                    static mut #_name: #krate::UntaggedOption<#ty> = #krate::UntaggedOption { none: () };
                 },
             });
         }
@@ -587,7 +587,7 @@ fn tasks(app: &App, ownerships: &Ownerships, root: &mut Vec<Tokens>) {
                                 }
                             } else {
                                 quote! {
-                                    #name: ::#krate::Static::ref_mut(&mut ::#_name.init),
+                                    #name: ::#krate::Static::ref_mut(::#_name.as_mut()),
                                 }
                             });
                         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,9 @@ use core::u8;
 pub use rtfm_core::{Resource, Static, Threshold};
 pub use cortex_m::asm::{bkpt, wfi};
 pub use cortex_m_rtfm_macros::app;
+#[doc(hidden)]
 pub use untagged_option::UntaggedOption;
+
 use cortex_m::interrupt::{self, Nr};
 #[cfg(not(armv6m))]
 use cortex_m::register::basepri;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,11 +80,10 @@
 extern crate cortex_m;
 extern crate cortex_m_rtfm_macros;
 extern crate rtfm_core;
-extern crate static_ref;
 
 use core::u8;
 
-pub use rtfm_core::{Resource, Static, Threshold};
+pub use rtfm_core::{Resource, LateResource, Static, Threshold};
 pub use cortex_m::asm::{bkpt, wfi};
 pub use cortex_m_rtfm_macros::app;
 use cortex_m::interrupt::{self, Nr};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,12 +80,14 @@
 extern crate cortex_m;
 extern crate cortex_m_rtfm_macros;
 extern crate rtfm_core;
+extern crate untagged_option;
 
 use core::u8;
 
-pub use rtfm_core::{Resource, LateResource, Static, Threshold};
+pub use rtfm_core::{Resource, Static, Threshold};
 pub use cortex_m::asm::{bkpt, wfi};
 pub use cortex_m_rtfm_macros::app;
+pub use untagged_option::UntaggedOption;
 use cortex_m::interrupt::{self, Nr};
 #[cfg(not(armv6m))]
 use cortex_m::register::basepri;

--- a/tests/cfail.rs
+++ b/tests/cfail.rs
@@ -3,10 +3,11 @@ extern crate compiletest_rs as compiletest;
 use std::path::PathBuf;
 
 use compiletest::common::Mode;
+use compiletest::Config;
 
 #[test]
 fn cfail() {
-    let mut config = compiletest::default_config();
+    let mut config = Config::default();
     config.mode = Mode::CompileFail;
     config.src_base = PathBuf::from(format!("tests/cfail"));
     config.target_rustcflags = Some(

--- a/tests/cfail/late-resource-init.rs
+++ b/tests/cfail/late-resource-init.rs
@@ -1,0 +1,49 @@
+#![deny(warnings)]
+#![feature(proc_macro)]
+#![no_std]
+
+extern crate cortex_m_rtfm as rtfm;
+extern crate stm32f103xx;
+
+use rtfm::{app, Threshold};
+
+app! {
+    device: stm32f103xx,
+
+    resources: {
+        static A: u8 = 0;
+        static LATE: u8;
+    },
+
+    tasks: {
+        EXTI0: {
+            path: exti0,
+            priority: 1,
+            resources: [A, LATE],
+        },
+
+        EXTI1: {
+            path: exti1,
+            priority: 2,
+            resources: [A, LATE],
+        },
+    },
+}
+
+fn init(_p: init::Peripherals, r: init::Resources) -> init::LateResourceValues {
+    // Try to use a resource that's not yet initialized:
+    r.LATE;
+    //~^ error: no field `LATE`
+
+    init::LateResourceValues {
+        LATE: 0,
+    }
+}
+
+fn idle() -> ! {
+    loop {}
+}
+
+fn exti0(_t: &mut Threshold, _r: EXTI0::Resources) {}
+
+fn exti1(_t: &mut Threshold, _r: EXTI1::Resources) {}

--- a/tests/cfail/wrong-threshold.rs
+++ b/tests/cfail/wrong-threshold.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![feature(const_fn)]
 #![feature(proc_macro)]
 #![no_std]
 
@@ -46,4 +45,4 @@ fn exti0(mut ot: &mut Threshold, r: EXTI0::Resources) {
     });
 }
 
-fn exti1(_t: &mut Threshold, r: EXTI1::Resources) {}
+fn exti1(_t: &mut Threshold, _r: EXTI1::Resources) {}


### PR DESCRIPTION
Closes #37 

TODO:
* [X] Open dependent PRs
  * [x] Get them merged
* [X] Add an example ~~(I cannot currently run any of the examples since I "only" have an stm32f401)~~
* [x] Add a cfail test ensuring that `init` cannot access uninitialized resources (and possibly other tests)
  * Figure out why I cannot run these tests
* [x] Simplify code, it's quite ugly