### PR TITLE
[WIP] travis: disable cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,6 @@ script:
 
 after_script: set +e
 
-cache: cargo
-before_cache:
-  - chmod -R a+r $HOME/.cargo
-
 branches:
   only:
     - auto

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,6 @@
 extern crate cortex_m;
 extern crate cortex_m_rtfm_macros;
 extern crate rtfm_core;
-extern crate static_ref;
 
 use core::u8;
 


### PR DESCRIPTION
Travis is currently working with an old yanked version of the
stm32f103xx crate (0.7.2). This is bad.

CI will probably fail on this PR.