### PR TITLE
[RFC] rename LateResourceValues to LateResources

### DIFF
--- a/examples/generics.rs
+++ b/examples/generics.rs
@@ -32,8 +32,8 @@ app! {
     },
 }
 
-fn init(p: init::Peripherals) -> init::LateResourceValues {
-    init::LateResourceValues {
+fn init(p: init::Peripherals) -> init::LateResources {
+    init::LateResources {
         GPIOA: p.device.GPIOA,
         SPI1: p.device.SPI1,
     }

--- a/examples/late-resources.rs
+++ b/examples/late-resources.rs
@@ -55,7 +55,7 @@ app! {
 }
 
 // The signature of `init` is now required to have a specific return type.
-fn init(_p: init::Peripherals, _r: init::Resources) -> init::LateResourceValues {
+fn init(_p: init::Peripherals, _r: init::Resources) -> init::LateResources {
     // `init::Resources` does not contain `IP_ADDRESS`, since it is not yet
     // initialized.
     //_r.IP_ADDRESS;     // doesn't compile
@@ -63,7 +63,7 @@ fn init(_p: init::Peripherals, _r: init::Resources) -> init::LateResourceValues 
     // ...obtain value for IP_ADDRESS from EEPROM/DHCP...
     let ip_address = 0x7f000001;
 
-    init::LateResourceValues {
+    init::LateResources {
         // This struct will contain fields for all resources with omitted
         // initializers.
         IP_ADDRESS: ip_address,

--- a/macros/src/trans.rs
+++ b/macros/src/trans.rs
@@ -234,17 +234,17 @@ fn init(app: &App, main: &mut Vec<Tokens>, root: &mut Vec<Tokens>) {
         root.push(quote! {
             #[allow(non_camel_case_types)]
             #[allow(non_snake_case)]
-            pub struct _initLateResourceValues {
+            pub struct _initLateResources {
                 #(#fields)*
             }
         });
 
         mod_items.push(quote! {
-            pub use ::_initLateResourceValues as LateResourceValues;
+            pub use ::_initLateResources as LateResources;
         });
 
         // `init` must return the initialized resources
-        ret = Some(quote!( -> ::init::LateResourceValues));
+        ret = Some(quote!( -> ::init::LateResources));
     }
 
     root.push(quote! {

--- a/src/examples/_5_late_resources.rs
+++ b/src/examples/_5_late_resources.rs
@@ -57,7 +57,7 @@
 //! }
 //! 
 //! // The signature of `init` is now required to have a specific return type.
-//! fn init(_p: init::Peripherals, _r: init::Resources) -> init::LateResourceValues {
+//! fn init(_p: init::Peripherals, _r: init::Resources) -> init::LateResources {
 //!     // `init::Resources` does not contain `IP_ADDRESS`, since it is not yet
 //!     // initialized.
 //!     //_r.IP_ADDRESS;     // doesn't compile
@@ -65,7 +65,7 @@
 //!     // ...obtain value for IP_ADDRESS from EEPROM/DHCP...
 //!     let ip_address = 0x7f000001;
 //! 
-//!     init::LateResourceValues {
+//!     init::LateResources {
 //!         // This struct will contain fields for all resources with omitted
 //!         // initializers.
 //!         IP_ADDRESS: ip_address,

--- a/tests/cfail/late-resource-init.rs
+++ b/tests/cfail/late-resource-init.rs
@@ -30,12 +30,12 @@ app! {
     },
 }
 
-fn init(_p: init::Peripherals, r: init::Resources) -> init::LateResourceValues {
+fn init(_p: init::Peripherals, r: init::Resources) -> init::LateResources {
     // Try to use a resource that's not yet initialized:
     r.LATE;
     //~^ error: no field `LATE`
 
-    init::LateResourceValues {
+    init::LateResources {
         LATE: 0,
     }
 }


### PR DESCRIPTION
After writing `LateResourceValues` several times I now think it's too long to type. I'd like that
struct to be renamed to `LateResources`. I don't think there would be a loss in readability with the
rename because you can think of "late resources" as resources that "don't exist" until `init` ends
instead of as resources that are not initialized after `init` ends -- the second meaning maps better
to `LateResourceValues`.

This would be a breaking-change but we are moving to v0.3.0 due to #50 in any case.

cc jonas-schievink