### PR TITLE
work around Cortex-M7 BASEPRI erratum

### DIFF
--- a/macros/src/trans.rs
+++ b/macros/src/trans.rs
@@ -181,6 +181,7 @@ fn idle(app: &App, ownerships: &Ownerships, main: &mut Vec<Tokens>, root: &mut V
                             &#_static,
                             #ceiling,
                             #device::NVIC_PRIO_BITS,
+                            #device::CPU,
                             t,
                             f,
                         )
@@ -196,6 +197,7 @@ fn idle(app: &App, ownerships: &Ownerships, main: &mut Vec<Tokens>, root: &mut V
                             &mut #_static,
                             #ceiling,
                             #device::NVIC_PRIO_BITS,
+                            #device::CPU,
                             t,
                             f,
                         )
@@ -499,6 +501,7 @@ fn tasks(app: &App, ownerships: &Ownerships, root: &mut Vec<Tokens>) {
                                     &#_static,
                                     #ceiling,
                                     #device::NVIC_PRIO_BITS,
+                                    #device::CPU,
                                     t,
                                     f,
                                 )
@@ -514,6 +517,7 @@ fn tasks(app: &App, ownerships: &Ownerships, root: &mut Vec<Tokens>) {
                                     &mut #_static,
                                     #ceiling,
                                     #device::NVIC_PRIO_BITS,
+                                    #device::CPU,
                                     t,
                                     f,
                                 )


### PR DESCRIPTION
This PR works around the issue in RTFM and depends on the SVD file properly declaring the CPU name.

The other solution to the problem is to patch the issue in the cortex-m crate: i.e. to patch the
`register::basepri::write` method. In that context there's no CPU information so we'll have to apply
the fix to the `thumbv7m-none-eabi`, `thumbv7em-none-eabi` and `thumbv7em-none-eabihf` targets --
which would negatively affect several applications.

It should be noted that this PR would leave `cortex_m::basepri::write` broken for Cortex-M7 targets.

cc @perlindgren
see #53 for background information
depends on japaric/svd2rust#163