### PR TITLE
specify both the path and version of the cortex-m-rtfm-macros dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.3.1"
 
 [dependencies]
 cortex-m = "0.4.0"
-cortex-m-rtfm-macros = { path = "macros" }
+cortex-m-rtfm-macros = { path = "macros", version = "0.3.0" }
 rtfm-core = "0.2.0"
 untagged-option = "0.1.1"
 


### PR DESCRIPTION
this seems to be required for cargo publish to Just Work

cc @jonas-schievink