### PR TITLE
update parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,7 @@ script:
 
 after_script: set +e
 
-cache:
-  cargo: true
-  directories:
-    - $HOME/.xargo
+cache: cargo
 before_cache:
   - chmod -R a+r $HOME/.cargo
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,7 +1,9 @@
 set -euxo pipefail
 
 main() {
-    :
+    if [ $TARGET != x86_64-unknown-linux-gnu ]; then
+        rustup target add $TARGET
+    fi
 }
 
 main

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,14 +1,7 @@
 set -euxo pipefail
 
 main() {
-    case $TARGET in
-        thumbv*-none-eabi*)
-            cargo install --list | grep 'xargo v0.3.8' || \
-                cargo install xargo --vers 0.3.8
-            rustup component list | grep 'rust-src.*installed' || \
-                rustup component add rust-src
-            ;;
-    esac
+    .
 }
 
 main

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,7 +1,7 @@
 set -euxo pipefail
 
 main() {
-    .
+    :
 }
 
 main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -9,13 +9,13 @@ main() {
 
     case $TARGET in
         thumbv7em-none-eabi*)
-            xargo check --target $TARGET --features cm7-r0p1
-            xargo check --target $TARGET --features cm7-r0p1 --examples
+            cargo check --target $TARGET --features cm7-r0p1
+            cargo check --target $TARGET --features cm7-r0p1 --examples
         ;;
     esac
 
-    xargo check --target $TARGET
-    xargo check --target $TARGET --examples
+    cargo check --target $TARGET
+    cargo check --target $TARGET --examples
 }
 
 main

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -10,8 +10,8 @@
 extern crate cortex_m_rtfm as rtfm;
 extern crate stm32f103xx;
 
-use stm32f103xx::Interrupt;
 use rtfm::{app, Resource, Threshold};
+use stm32f103xx::Interrupt;
 
 app! {
     device: stm32f103xx,
@@ -60,10 +60,7 @@ fn idle() -> ! {
 }
 
 #[allow(non_snake_case)]
-fn exti0(
-    t: &mut Threshold,
-    EXTI0::Resources { mut LOW, mut HIGH }: EXTI0::Resources,
-) {
+fn exti0(t: &mut Threshold, EXTI0::Resources { mut LOW, mut HIGH }: EXTI0::Resources) {
     // Because this task has a priority of 1 the preemption threshold `t` also
     // starts at 1
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -10,10 +10,11 @@ repository = "https://github.com/japaric/cortex-m-rtfm"
 version = "0.3.0"
 
 [dependencies]
-error-chain = "0.10.0"
-quote = "0.3.15"
-rtfm-syntax = "0.2.1"
-syn = "0.11.11"
+failure = "0.1.1"
+proc-macro2 = "0.3.6"
+quote = "0.5.1"
+rtfm-syntax = { git = "https://github.com/japaric/rtfm-syntax", branch = "syn-up" }
+syn = "0.13.1"
 
 [lib]
 proc-macro = true

--- a/macros/src/analyze.rs
+++ b/macros/src/analyze.rs
@@ -40,7 +40,7 @@ pub fn app(app: &App) -> Ownerships {
     }
 
     for task in app.tasks.values() {
-        for resource in &task.resources {
+        for resource in task.resources.iter() {
             if let Some(ownership) = ownerships.get_mut(resource) {
                 match *ownership {
                     Ownership::Owned { priority } => {

--- a/macros/src/check.rs
+++ b/macros/src/check.rs
@@ -1,10 +1,8 @@
 use std::collections::HashMap;
 
 use syn::{Ident, Path};
-use syntax::check::{self, Idle, Init};
-use syntax::{self, Resources, Statics};
-
-use syntax::error::*;
+use syntax::check::{self, Idents, Idle, Init, Statics};
+use syntax::{self, Result};
 
 pub struct App {
     pub device: Path,
@@ -51,7 +49,7 @@ pub struct Task {
     pub kind: Kind,
     pub path: Path,
     pub priority: u8,
-    pub resources: Resources,
+    pub resources: Idents,
 }
 
 pub fn app(app: check::App) -> Result<App> {
@@ -63,78 +61,14 @@ pub fn app(app: check::App) -> Result<App> {
         tasks: app.tasks
             .into_iter()
             .map(|(k, v)| {
-                let v =
-                    ::check::task(k.as_ref(), v).chain_err(|| format!("checking task `{}`", k))?;
+                let v = ::check::task(k.as_ref(), v)?;
 
                 Ok((k, v))
             })
             .collect::<Result<_>>()?,
     };
 
-    ::check::resources(&app).chain_err(|| "checking `resources`")?;
-
     Ok(app)
-}
-
-fn resources(app: &App) -> Result<()> {
-    for name in &app.init.resources {
-        if let Some(resource) = app.resources.get(name) {
-            ensure!(
-                resource.expr.is_some(),
-                "resource `{}`, allocated to `init`, must have an initial value",
-                name
-            );
-        } else {
-            bail!(
-                "resource `{}`, allocated to `init`, must be a data resource",
-                name
-            );
-        }
-
-        ensure!(
-            !app.idle.resources.contains(name),
-            "resources assigned to `init` can't be shared with `idle`"
-        );
-
-        ensure!(
-            app.tasks
-                .iter()
-                .all(|(_, task)| !task.resources.contains(name)),
-            "resources assigned to `init` can't be shared with tasks"
-        )
-    }
-
-    for resource in app.resources.keys() {
-        if app.init.resources.contains(resource) {
-            continue;
-        }
-
-        if app.idle.resources.contains(resource) {
-            continue;
-        }
-
-        if app.tasks
-            .values()
-            .any(|task| task.resources.contains(resource))
-        {
-            continue;
-        }
-
-        bail!("resource `{}` is unused", resource);
-    }
-
-    for (name, task) in &app.tasks {
-        for resource in &task.resources {
-            ensure!(
-                app.resources.contains_key(&resource),
-                "task {} contains an undeclared resource with name {}",
-                name,
-                resource
-            );
-        }
-    }
-
-    Ok(())
 }
 
 fn task(name: &str, task: syntax::check::Task) -> Result<Task> {
@@ -147,23 +81,14 @@ fn task(name: &str, task: syntax::check::Task) -> Result<Task> {
 
             Kind::Exception(e)
         }
-        None => {
-            if task.enabled == Some(true) {
-                bail!(
-                    "`enabled: true` is the default value; this line can be \
-                     omitted"
-                );
-            }
-
-            Kind::Interrupt {
-                enabled: task.enabled.unwrap_or(true),
-            }
-        }
+        None => Kind::Interrupt {
+            enabled: task.enabled.unwrap_or(true),
+        },
     };
 
     Ok(Task {
         kind,
-        path: task.path.ok_or("`path` field is missing")?,
+        path: task.path,
         priority: task.priority.unwrap_or(1),
         resources: task.resources,
     })

--- a/tests/cfail.rs
+++ b/tests/cfail.rs
@@ -10,9 +10,8 @@ fn cfail() {
     let mut config = Config::default();
     config.mode = Mode::CompileFail;
     config.src_base = PathBuf::from(format!("tests/cfail"));
-    config.target_rustcflags = Some(
-        "-C panic=abort -L target/debug -L target/debug/deps ".to_string(),
-    );
+    config.target_rustcflags =
+        Some("-C panic=abort -L target/debug -L target/debug/deps ".to_string());
 
     compiletest::run_tests(&config);
 }

--- a/tests/cfail/init-resource-share-idle.rs
+++ b/tests/cfail/init-resource-share-idle.rs
@@ -19,8 +19,8 @@ app! { //~ proc macro panicked
     },
 
     idle: {
-        // ERROR resources assigned to `init` can't be shared with `idle`
         resources: [BUFFER],
+        //~^ error: this resource is owned by `init` and can't be shared
     },
 }
 

--- a/tests/cfail/init-resource-share-task.rs
+++ b/tests/cfail/init-resource-share-task.rs
@@ -21,8 +21,8 @@ app! { //~ proc macro panicked
     tasks: {
         SYS_TICK: {
             path: sys_tick,
-            // ERROR resources assigned to `init` can't be shared with tasks
             resources: [BUFFER],
+            //~^ error: this resource is owned by `init` and can't be shared
         },
     },
 }

--- a/tests/cfail/interrupt.rs
+++ b/tests/cfail/interrupt.rs
@@ -8,12 +8,10 @@ extern crate stm32f103xx;
 
 use rtfm::app;
 
-app! {
-    //~^ error no variant named `EXTI33` found for type
+app! { //~ error no variant named `EXTI33` found for type
     device: stm32f103xx,
 
     tasks: {
-        // ERROR this interrupt doesn't exist
         EXTI33: {
             path: exti33,
         },

--- a/tests/cfail/priority-too-high.rs
+++ b/tests/cfail/priority-too-high.rs
@@ -9,6 +9,7 @@ extern crate stm32f103xx;
 use rtfm::app;
 
 app! { //~ error attempt to subtract with overflow
+    //~^ error constant evaluation error
     device: stm32f103xx,
 
     tasks: {

--- a/tests/cfail/priority-too-low.rs
+++ b/tests/cfail/priority-too-low.rs
@@ -9,6 +9,7 @@ extern crate stm32f103xx;
 use rtfm::app;
 
 app! { //~ error attempt to subtract with overflow
+    //~^ error constant evaluation error
     device: stm32f103xx,
 
     tasks: {

--- a/tests/cfail/resource-not-send-sync.rs
+++ b/tests/cfail/resource-not-send-sync.rs
@@ -7,7 +7,7 @@
 extern crate cortex_m_rtfm as rtfm;
 extern crate stm32f103xx;
 
-use rtfm::{app, Resource, Threshold};
+use rtfm::{app, Threshold};
 
 app! {
     device: stm32f103xx,
@@ -43,7 +43,7 @@ fn is_sync<T>(_: &T) where T: Sync {}
 fn exti0(_t: &mut Threshold, r: EXTI0::Resources) {
     // ERROR resource proxies can't be shared between tasks
     is_sync(&r.SHARED);
-    //~^ error the trait bound `*const (): core::marker::Sync` is not satisfied
+    //~^ error `*const ()` cannot be shared between threads safely
 
     // ERROR resource proxies are not `Send`able across tasks
     is_send(&r.SHARED);


### PR DESCRIPTION
closes #69

this doesn't change functionality per se but improves diagnostics in some cases. Some hard errors
have becomes warnings, for example: when `resources` is empty, or when `idle.path` is set to the
default `idle` path.