### PR TITLE
Unused resource is not declared

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -11,10 +11,10 @@ version = "0.3.1"
 
 [dependencies]
 failure = "0.1.1"
-proc-macro2 = "0.3.6"
-quote = "0.5.1"
-rtfm-syntax = "0.3.0"
-syn = "0.13.1"
+proc-macro2 = "0.4"
+quote = "0.6"
+rtfm-syntax = "0.3.4"
+syn = "0.14"
 
 [lib]
 proc-macro = true

--- a/macros/src/check.rs
+++ b/macros/src/check.rs
@@ -61,7 +61,7 @@ pub fn app(app: check::App) -> Result<App> {
         tasks: app.tasks
             .into_iter()
             .map(|(k, v)| {
-                let v = ::check::task(k.as_ref(), v)?;
+                let v = ::check::task(&k.to_string(), v)?;
 
                 Ok((k, v))
             })

--- a/macros/src/trans.rs
+++ b/macros/src/trans.rs
@@ -16,7 +16,7 @@ pub fn app(app: &App, ownerships: &Ownerships) -> Tokens {
     ::trans::tasks(app, ownerships, &mut root, &mut main);
     ::trans::init(app, &mut main, &mut root);
     ::trans::idle(app, ownerships, &mut main, &mut root);
-    ::trans::resources(app, ownerships, &mut root);
+    ::trans::resources(app, &mut root);
 
     root.push(quote! {
         #[allow(unsafe_code)]
@@ -415,17 +415,13 @@ fn init(app: &App, main: &mut Vec<Tokens>, root: &mut Vec<Tokens>) {
     });
 }
 
-fn resources(app: &App, ownerships: &Ownerships, root: &mut Vec<Tokens>) {
+fn resources(app: &App, root: &mut Vec<Tokens>) {
     let krate = krate();
 
-    for name in ownerships.keys() {
-        let _name = Ident::from(format!("_{}", name.as_ref()));
+    for (name, resource) in app.resources.iter() {
+        let _name = Ident::from(format!("_{}", name));
 
         // Declare the static that holds the resource
-        let resource = app.resources
-            .get(name)
-            .expect(&format!("BUG: resource {} has no definition", name));
-
         let expr = &resource.expr;
         let ty = &resource.ty;
 


### PR DESCRIPTION
Declare statics for all resources not just those with an ownership (that are used in a task or idle).
Used resources without definition are already found in `tasks()`.

I (more or less accidentally) had a resource, late-initialised by `init`, that was not used in any tasks. The compiler was rightfully complaining that `main` was trying to assign to a variable that didn't exist in scope.