### PR TITLE
Modified Resource to not always require Send

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ pub use cortex_m_rtfm_macros::app;
 use typenum::consts::*;
 use typenum::Unsigned;
 
-pub use resource::{Priority, Resource};
+pub use resource::{Priority, SharedResource, Resource};
 
 #[doc(hidden)]
 pub mod _impl;

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -31,7 +31,7 @@ pub unsafe trait Resource {
     type Ceiling;
 
     /// The data protected by the resource
-    type Data: 'static + Send;
+    type Data: 'static;
 
     // The `static mut` variable that the resource protects fs
     #[doc(hidden)]
@@ -103,4 +103,11 @@ pub unsafe trait Resource {
             }
         }
     }
+}
+
+/// A Resource that may be shared between multiple threads
+pub trait SharedResource: Resource
+where
+    <Self as Resource>::Data: Send,
+{
 }


### PR DESCRIPTION
It is possible that some tasks will need a resource that is
initialized at runtime, but is not send (for example, the motivating
example is a smoltcp interface). This patch makes it so that a
resource that is only ever used in one task does not need to be Send.

Compatibility issues:
 * Anything that depends on `<T as Resource>::Data : Send` should
   instead assert that `T: SharedResource`