### PR TITLE
Fix "Could not find `Op` in `proc_macro`"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,6 @@ cortex-m = "0.4.0"
 cortex-m-rtfm-macros = { path = "macros", version = "0.3.1" }
 rtfm-core = "0.2.0"
 untagged-option = "0.1.1"
-syn = "0.14.2"
-quote = "0.6.3"
-proc-macro2 = "0.4.6"
-failure = "0.1.1"
 
 [target.'cfg(target_arch = "x86_64")'.dev-dependencies]
 compiletest_rs = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ cortex-m = "0.4.0"
 cortex-m-rtfm-macros = { path = "macros", version = "0.3.1" }
 rtfm-core = "0.2.0"
 untagged-option = "0.1.1"
+syn = "0.14.2"
+quote = "0.6.3"
+proc-macro2 = "0.4.6"
+failure = "0.1.1"
 
 [target.'cfg(target_arch = "x86_64")'.dev-dependencies]
 compiletest_rs = "0.3.5"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -11,10 +11,10 @@ version = "0.3.1"
 
 [dependencies]
 failure = "0.1.1"
-proc-macro2 = "0.3.6"
-quote = "0.5.1"
-rtfm-syntax = "0.3.0"
-syn = "0.13.1"
+proc-macro2 = "0.4.6"
+quote = "0.6.3"
+rtfm-syntax = {git = "https://github.com/chocol4te/rtfm-syntax.git"}
+syn = "0.14.2"
 
 [lib]
 proc-macro = true

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.3.1"
 failure = "0.1.1"
 proc-macro2 = "0.4.6"
 quote = "0.6.3"
-rtfm-syntax = {git = "https://github.com/chocol4te/rtfm-syntax.git"}
+rtfm-syntax = "0.3.4"
 syn = "0.14.2"
 
 [lib]

--- a/macros/src/check.rs
+++ b/macros/src/check.rs
@@ -61,7 +61,7 @@ pub fn app(app: check::App) -> Result<App> {
         tasks: app.tasks
             .into_iter()
             .map(|(k, v)| {
-                let v = ::check::task(k.as_ref(), v)?;
+                let v = ::check::task(&k.to_string(), v)?;
 
                 Ok((k, v))
             })

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,6 +1,5 @@
 //! Procedural macros of the `cortex-m-rtfm` crate
 // #![deny(warnings)]
-#![feature(proc_macro)]
 #![recursion_limit = "128"]
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,6 @@
 //! [rtfm]: http://www.diva-portal.org/smash/get/diva2:1005680/FULLTEXT01.pdf
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![feature(proc_macro)]
 #![no_std]
 
 extern crate cortex_m;


### PR DESCRIPTION
Fixes nightly error with `proc-macro2`. 

Should not be merged until https://github.com/japaric/rtfm-syntax/pull/8 is merged and new `rtfm-syntax` version is published.