### PR TITLE
codegen: stop using `export_name`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m-rtfm"
 readme = "README.md"
 repository = "https://github.com/japaric/cortex-m-rtfm"
-version = "0.4.0-beta.2"
+version = "0.4.0-beta.3"
 
 [lib]
 name = "rtfm"
@@ -36,7 +36,7 @@ required-features = ["timer-queue"]
 [dependencies]
 cortex-m = "0.5.8"
 cortex-m-rt = "0.6.5"
-cortex-m-rtfm-macros = { path = "macros", version = "0.4.0-beta.2" }
+cortex-m-rtfm-macros = { path = "macros", version = "0.4.0-beta.3" }
 heapless = "0.4.0"
 owned-singleton = "0.1.0"
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m-rtfm-macros"
 readme = "../README.md"
 repository = "https://github.com/japaric/cortex-m-rtfm"
-version = "0.4.0-beta.2"
+version = "0.4.0-beta.3"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
`export_name` creates external symbols that won't be removed when using `-Z
emit-stack-sizes`