### PR TITLE
Absolute link to the book so it works on crates.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Use an absolute link to the book so it works when landing from crates.io
+  documentation page
+
 ## [v0.4.0] - 2018-11-03
 
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! The user level documentation can be found [here].
 //!
-//! [here]: ../../book/
+//! [here]: https://japaric.github.io/cortex-m-rtfm/book/
 //!
 //! Don't forget to check the documentation of the [`#[app]`] attribute, which is the main component
 //! of the framework.


### PR DESCRIPTION
```
<eddyp> japaric: is https://docs.rs/cortex-m-rtfm/book/ supposed to be a "dead" link?
* peri_ (peri@moz-c2q.111.74.96.IP) has joined
* peri_ has quit (Connection closed)
<japaric> eddyp: yes, the correct URL is https://japaric.github.io/cortex-m-rtfm/book/ ; does something link to docs.rs/*/book?
 japaric Jackneill Jacob_____ jamesmunns jasper jayaura 
* peri has quit (Connection closed)
* peri_ (peri@moz-c2q.111.74.96.IP) has joined
<eddyp> japaric: https://docs.rs/cortex-m-rtfm/0.4.0/rtfm/ 
<eddyp> probably relative link?
<eddyp> at "The user level documentation can be found here."
<japaric> eddyp: probably. If you want to score some GH points you can send a PR to make the url absolute
 japaric Jackneill Jacob_____ jamesmunns jasper jayaura 
<eddyp> japaric: I can do it tomorrow since is almost 2am, but where's the source?
<eddyp> I'm not familiar with crate publishing 
<japaric> eddyp: https://github.com/japaric/cortex-m-rtfm/blob/master/src/lib.rs#L10
<therealprof> eddyp: All metadata is in Cargo.toml
<eddyp> so I need to also bump the version to 0.4.1?
<adamgreig> you just want to make a github pull request updating cargo.toml, not updating the crate version or publishing a new crate etc
<adamgreig> the crate version update and publication happens at some point in the future
<adamgreig> updating the documentation link that is, sorry
<therealprof> That.
<eddyp> The Cargo.toml contains good .... ah, OK
* peri_ has quit (Ping timeout: 121 seconds)
<therealprof> And potentially the CHANGELOG.md if there's one.
```