### PR TITLE
make builds reproducible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /book/*/book
 /target
 Cargo.lock
+*.hex

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,10 @@ matrix:
       rust: nightly
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
-before_install: set -e
+before_install:
+  - set -e
+  - sudo apt-get update
+  - sudo apt-get install -y binutils-arm-none-eabi
 
 install:
   - bash ci/install.sh

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -139,15 +139,15 @@ main() {
                 fi
 
                 if [ $ex != types ]; then
-                    arm_example "build" $ex "debug" "" "2"
-                    cmp ci/builds/${ex}_debug_1.hex ci/builds/${ex}_debug_2.hex
+                    # arm_example "build" $ex "debug" "" "2"
+                    # cmp ci/builds/${ex}_debug_1.hex ci/builds/${ex}_debug_2.hex
                     arm_example "build" $ex "release" "" "2"
                     cmp ci/builds/${ex}_release_1.hex ci/builds/${ex}_release_2.hex
                 fi
 
                 if [ $TARGET != thumbv6m-none-eabi ]; then
-                    arm_example "build" $ex "debug" "timer-queue" "2"
-                    cmp ci/builds/${ex}_timer-queue_debug_1.hex ci/builds/${ex}_timer-queue_debug_2.hex
+                    # arm_example "build" $ex "debug" "timer-queue" "2"
+                    # cmp ci/builds/${ex}_timer-queue_debug_1.hex ci/builds/${ex}_timer-queue_debug_2.hex
                     arm_example "build" $ex "release" "timer-queue" "2"
                     cmp ci/builds/${ex}_timer-queue_release_1.hex ci/builds/${ex}_timer-queue_release_2.hex
                 fi

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -139,15 +139,15 @@ main() {
                 fi
 
                 if [ $ex != types ]; then
-                    # arm_example "build" $ex "debug" "" "2"
-                    # cmp ci/builds/${ex}_debug_1.hex ci/builds/${ex}_debug_2.hex
+                    arm_example "build" $ex "debug" "" "2"
+                    cmp ci/builds/${ex}_debug_1.hex ci/builds/${ex}_debug_2.hex
                     arm_example "build" $ex "release" "" "2"
                     cmp ci/builds/${ex}_release_1.hex ci/builds/${ex}_release_2.hex
                 fi
 
                 if [ $TARGET != thumbv6m-none-eabi ]; then
-                    # arm_example "build" $ex "debug" "timer-queue" "2"
-                    # cmp ci/builds/${ex}_timer-queue_debug_1.hex ci/builds/${ex}_timer-queue_debug_2.hex
+                    arm_example "build" $ex "debug" "timer-queue" "2"
+                    cmp ci/builds/${ex}_timer-queue_debug_1.hex ci/builds/${ex}_timer-queue_debug_2.hex
                     arm_example "build" $ex "release" "timer-queue" "2"
                     cmp ci/builds/${ex}_timer-queue_release_1.hex ci/builds/${ex}_timer-queue_release_2.hex
                 fi

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,5 +1,36 @@
 set -euxo pipefail
 
+arm_example() {
+    local COMMAND=$1
+    local EXAMPLE=$2
+    local BUILD_MODE=$3
+    local FEATURES=$4
+    local BUILD_NUM=$5
+
+    if [ $BUILD_MODE = "release" ]; then
+        local RELEASE_FLAG="--release"
+    else
+        local RELEASE_FLAG=""
+    fi
+
+    if [ -n "$FEATURES" ]; then
+        local FEATURES_FLAG="--features $FEATURES"
+        local FEATURES_STR=${FEATURES/,/_}_
+    else
+        local FEATURES_FLAG=""
+        local FEATURES_STR=""
+    fi
+    local CARGO_FLAGS="--example $EXAMPLE --target $TARGET $RELEASE_FLAG $FEATURES_FLAG"
+
+    if [ $COMMAND = "run" ]; then
+        cargo $COMMAND $CARGO_FLAGS | diff -u ci/expected/$EXAMPLE.run -
+    else
+        cargo $COMMAND $CARGO_FLAGS
+    fi
+    arm-none-eabi-objcopy -O ihex target/$TARGET/$BUILD_MODE/examples/$EXAMPLE ${EXAMPLE}_${FEATURES_STR}${BUILD_MODE}_${BUILD_NUM}.hex
+}
+
+
 main() {
     local T=$TARGET
 
@@ -81,45 +112,31 @@ main() {
                     continue
                 fi
 
-                test_arm_example() {
-                    local EXAMPLE=$1
-                    local TARGET=$2
-                    local BUILD_MODE=$3
-                    local FEATURES=$4
-
-                    if [ $BUILD_MODE = "release" ]; then
-                        local RELEASE_FLAG="--release"
-                    else
-                        local RELEASE_FLAG=""
-                    fi
-
-                    if [ -n "$FEATURES" ]; then
-                        local FEATURES_FLAG="--features $FEATURES"
-                    else
-                        local FEATURES_FLAG=""
-                    fi
-                    local CARGO_FLAGS="--example $EXAMPLE --target $TARGET $RELEASE_FLAG $FEATURES_FLAG"
-
-                    cargo run $CARGO_FLAGS | diff -u ci/expected/$EXAMPLE.run -
-                    arm-none-eabi-objcopy -O ihex target/$TARGET/$BUILD_MODE/examples/$EXAMPLE ${EXAMPLE}_1.hex
-
-                    # build again to ensure that the build is reproducable
-                    cargo clean
-                    cargo build $CARGO_FLAGS
-                    arm-none-eabi-objcopy -O ihex target/$TARGET/$BUILD_MODE/examples/$EXAMPLE ${EXAMPLE}_2.hex
-
-                    # compare results of both builds
-                    cmp ${EXAMPLE}_1.hex ${EXAMPLE}_2.hex
-                }
-
                 if [ $ex != types ]; then
-                    test_arm_example $ex $T "debug" ""
-                    test_arm_example $ex $T "release" ""
+                    arm_example "run" $ex "debug" "" "1"
+                    arm_example "run" $ex "release" "" "1"
                 fi
 
                 if [ $TARGET != thumbv6m-none-eabi ]; then
-                    test_arm_example $ex $T "debug" "timer-queue"
-                    test_arm_example $ex $T "release" "timer-queue"
+                    arm_example "run" $ex "debug" "timer-queue" "1"
+                    arm_example "run" $ex "release" "timer-queue" "1"
+                fi
+            done
+
+            cargo clean
+            for ex in ${exs[@]}; do
+                if [ $ex != types ]; then
+                    arm_example "build" $ex "debug" "" "2"
+                    cmp ${ex}_debug_1.hex ${ex}_debug_2.hex
+                    arm_example "build" $ex "release" "" "2"
+                    cmp ${ex}_release_1.hex ${ex}_release_2.hex
+                fi
+
+                if [ $TARGET != thumbv6m-none-eabi ]; then
+                    arm_example "build" $ex "debug" "timer-queue" "2"
+                    cmp ${ex}_timer-queue_debug_1.hex ${ex}_timer-queue_debug_2.hex
+                    arm_example "build" $ex "release" "timer-queue" "2"
+                    cmp ${ex}_timer-queue_release_1.hex ${ex}_timer-queue_release_2.hex
                 fi
             done
     esac

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -81,20 +81,45 @@ main() {
                     continue
                 fi
 
-                if [ $ex != types ]; then
-                    cargo run --example $ex --target $T | \
-                        diff -u ci/expected/$ex.run -
+                test_arm_example() {
+                    local EXAMPLE=$1
+                    local TARGET=$2
+                    local BUILD_MODE=$3
+                    local FEATURES=$4
 
-                    cargo run --example $ex --target $T --release | \
-                        diff -u ci/expected/$ex.run -
+                    if [ $BUILD_MODE = "release" ]; then
+                        local RELEASE_FLAG="--release"
+                    else
+                        local RELEASE_FLAG=""
+                    fi
+
+                    if [ -n "$FEATURES" ]; then
+                        local FEATURES_FLAG="--features $FEATURES"
+                    else
+                        local FEATURES_FLAG=""
+                    fi
+                    local CARGO_FLAGS="--example $EXAMPLE --target $TARGET $RELEASE_FLAG $FEATURES_FLAG"
+
+                    cargo run $CARGO_FLAGS | diff -u ci/expected/$EXAMPLE.run -
+                    arm-none-eabi-objcopy -O ihex target/$TARGET/$BUILD_MODE/examples/$EXAMPLE ${EXAMPLE}_1.hex
+
+                    # build again to ensure that the build is reproducable
+                    cargo clean
+                    cargo build $CARGO_FLAGS
+                    arm-none-eabi-objcopy -O ihex target/$TARGET/$BUILD_MODE/examples/$EXAMPLE ${EXAMPLE}_2.hex
+
+                    # compare results of both builds
+                    cmp ${EXAMPLE}_1.hex ${EXAMPLE}_2.hex
+                }
+
+                if [ $ex != types ]; then
+                    test_arm_example $ex $T "debug" ""
+                    test_arm_example $ex $T "release" ""
                 fi
 
                 if [ $TARGET != thumbv6m-none-eabi ]; then
-                    cargo run --features timer-queue --example $ex --target $T | \
-                        diff -u ci/expected/$ex.run -
-
-                    cargo run --features timer-queue --example $ex --target $T --release | \
-                        diff -u ci/expected/$ex.run -
+                    test_arm_example $ex $T "debug" "timer-queue"
+                    test_arm_example $ex $T "release" "timer-queue"
                 fi
             done
     esac

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -125,6 +125,12 @@ main() {
 
             cargo clean
             for ex in ${exs[@]}; do
+                if [ $ex = singleton ]; then
+                    # singleton build is currently not reproducible due to
+                    # https://github.com/japaric/owned-singleton/issues/2
+                    continue
+                fi
+
                 if [ $ex != types ]; then
                     arm_example "build" $ex "debug" "" "2"
                     cmp ${ex}_debug_1.hex ${ex}_debug_2.hex

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -27,12 +27,14 @@ arm_example() {
     else
         cargo $COMMAND $CARGO_FLAGS
     fi
-    arm-none-eabi-objcopy -O ihex target/$TARGET/$BUILD_MODE/examples/$EXAMPLE ${EXAMPLE}_${FEATURES_STR}${BUILD_MODE}_${BUILD_NUM}.hex
+    arm-none-eabi-objcopy -O ihex target/$TARGET/$BUILD_MODE/examples/$EXAMPLE ci/builds/${EXAMPLE}_${FEATURES_STR}${BUILD_MODE}_${BUILD_NUM}.hex
 }
 
 
 main() {
     local T=$TARGET
+
+    mkdir -p ci/builds
 
     if [ $T = x86_64-unknown-linux-gnu ]; then
         # compile-fail and compile-pass tests
@@ -138,16 +140,16 @@ main() {
 
                 if [ $ex != types ]; then
                     arm_example "build" $ex "debug" "" "2"
-                    cmp ${ex}_debug_1.hex ${ex}_debug_2.hex
+                    cmp ci/builds/${ex}_debug_1.hex ci/builds/${ex}_debug_2.hex
                     arm_example "build" $ex "release" "" "2"
-                    cmp ${ex}_release_1.hex ${ex}_release_2.hex
+                    cmp ci/builds/${ex}_release_1.hex ci/builds/${ex}_release_2.hex
                 fi
 
                 if [ $TARGET != thumbv6m-none-eabi ]; then
                     arm_example "build" $ex "debug" "timer-queue" "2"
-                    cmp ${ex}_timer-queue_debug_1.hex ${ex}_timer-queue_debug_2.hex
+                    cmp ci/builds/${ex}_timer-queue_debug_1.hex ci/builds/${ex}_timer-queue_debug_2.hex
                     arm_example "build" $ex "release" "timer-queue" "2"
-                    cmp ${ex}_timer-queue_release_1.hex ${ex}_timer-queue_release_2.hex
+                    cmp ci/builds/${ex}_timer-queue_release_1.hex ci/builds/${ex}_timer-queue_release_2.hex
                 fi
             done
     esac

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -125,6 +125,11 @@ main() {
 
             cargo clean
             for ex in ${exs[@]}; do
+                if [ $ex = ramfunc ] && [ $T = thumbv6m-none-eabi ]; then
+                    # LLD doesn't support this at the moment
+                    continue
+                fi
+
                 if [ $ex = singleton ]; then
                     # singleton build is currently not reproducible due to
                     # https://github.com/japaric/owned-singleton/issues/2

--- a/macros/src/analyze.rs
+++ b/macros/src/analyze.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp,
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
 };
 
 use syn::{Attribute, Ident, Type};
@@ -65,7 +65,7 @@ pub struct Dispatcher {
 }
 
 /// Priority -> Dispatcher
-pub type Dispatchers = HashMap<u8, Dispatcher>;
+pub type Dispatchers = BTreeMap<u8, Dispatcher>;
 
 pub type Capacities = HashMap<Ident, u8>;
 

--- a/macros/src/check.rs
+++ b/macros/src/check.rs
@@ -38,10 +38,10 @@ pub fn app(app: &App) -> parse::Result<()> {
     // Check that all late resources have been initialized in `#[init]` if `init` has signature
     // `fn()`
     if !app.init.returns_late_resources {
-        for res in app
-            .resources
-            .iter()
-            .filter_map(|(name, res)| if res.expr.is_none() { Some(name) } else { None })
+        for res in
+            app.resources
+                .iter()
+                .filter_map(|(name, res)| if res.expr.is_none() { Some(name) } else { None })
         {
             if app.init.assigns.iter().all(|assign| assign.left != *res) {
                 return Err(parse::Error::new(

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -68,17 +68,17 @@ impl Default for Context {
 
         Context {
             #[cfg(feature = "timer-queue")]
-            baseline: ident_gen.mk_ident(None),
+            baseline: ident_gen.mk_ident(None, false),
             dispatchers: BTreeMap::new(),
-            idle: ident_gen.mk_ident(Some("idle")),
-            init: ident_gen.mk_ident(Some("init")),
-            priority: ident_gen.mk_ident(None),
+            idle: ident_gen.mk_ident(Some("idle"), false),
+            init: ident_gen.mk_ident(Some("init"), false),
+            priority: ident_gen.mk_ident(None, false),
             statics: Aliases::new(),
             resources: HashMap::new(),
-            schedule_enum: ident_gen.mk_ident(None),
+            schedule_enum: ident_gen.mk_ident(None, false),
             schedule_fn: Aliases::new(),
             tasks: BTreeMap::new(),
-            timer_queue: ident_gen.mk_ident(None),
+            timer_queue: ident_gen.mk_ident(None, false),
             ident_gen,
         }
     }
@@ -174,7 +174,7 @@ pub fn app(app: &App, analysis: &Analysis) -> TokenStream {
 
     let assertions = assertions(app, analysis);
 
-    let main = ctxt.ident_gen.mk_ident(None);
+    let main = ctxt.ident_gen.mk_ident(None, false);
     quote!(
         #resources
 
@@ -240,7 +240,7 @@ fn resources(ctxt: &mut Context, app: &App, analysis: &Analysis) -> proc_macro2:
                 pub static #mut_ #name: #ty = #expr;
             ));
 
-            let alias = ctxt.ident_gen.mk_ident(None);
+            let alias = ctxt.ident_gen.mk_ident(None, true); // XXX is randomness required?
             if let Some(Ownership::Shared { ceiling }) = analysis.ownerships.get(name) {
                 items.push(mk_resource(
                     ctxt,
@@ -256,7 +256,7 @@ fn resources(ctxt: &mut Context, app: &App, analysis: &Analysis) -> proc_macro2:
 
             ctxt.statics.insert(name.clone(), alias);
         } else {
-            let alias = ctxt.ident_gen.mk_ident(None);
+            let alias = ctxt.ident_gen.mk_ident(None, false);
             let symbol = format!("{}::{}", name, alias);
 
             items.push(
@@ -409,7 +409,7 @@ fn init(ctxt: &mut Context, app: &App, analysis: &Analysis) -> (proc_macro2::Tok
     let baseline = &ctxt.baseline;
     let baseline_let = match () {
         #[cfg(feature = "timer-queue")]
-        () => quote!(let #baseline = rtfm::Instant::artificial(0);),
+        () => quote!(let ref #baseline = rtfm::Instant::artificial(0);),
 
         #[cfg(not(feature = "timer-queue"))]
         () => quote!(),
@@ -419,7 +419,7 @@ fn init(ctxt: &mut Context, app: &App, analysis: &Analysis) -> (proc_macro2::Tok
         #[cfg(feature = "timer-queue")]
         () => quote!(
             #[allow(unused_variables)]
-            let start = #baseline;
+            let start = *#baseline;
         ),
         #[cfg(not(feature = "timer-queue"))]
         () => quote!(),
@@ -434,21 +434,27 @@ fn init(ctxt: &mut Context, app: &App, analysis: &Analysis) -> (proc_macro2::Tok
 
             #module
 
+            // unsafe trampoline to deter end-users from calling this non-reentrant function
             #(#attrs)*
-            #unsafety fn #init(mut core: rtfm::Peripherals) #ret {
-                #(#locals)*
+            unsafe fn #init(core: rtfm::Peripherals) #ret {
+                #[inline(always)]
+                #unsafety fn init(mut core: rtfm::Peripherals) #ret {
+                    #(#locals)*
 
-                #baseline_let
+                    #baseline_let
 
-                #prelude
+                    #prelude
 
-                let mut device = unsafe { #device::Peripherals::steal() };
+                    let mut device = unsafe { #device::Peripherals::steal() };
 
-                #start_let
+                    #start_let
 
-                #(#stmts)*
+                    #(#stmts)*
 
-                #(#assigns)*
+                    #(#assigns)*
+                }
+
+                init(core)
             }
         ),
         has_late_resources,
@@ -567,7 +573,7 @@ fn module(
             #[derive(Clone, Copy)]
             pub struct Schedule<'a> {
                 #[doc(hidden)]
-                pub #priority: &'a core::cell::Cell<u8>,
+                pub #priority: &'a rtfm::export::Priority,
             }
         ));
     }
@@ -586,7 +592,7 @@ fn module(
                 #[derive(Clone, Copy)]
                 pub struct Spawn<'a> {
                     #[doc(hidden)]
-                    pub #priority: &'a core::cell::Cell<u8>,
+                    pub #priority: &'a rtfm::export::Priority,
                 }
             ));
         } else {
@@ -595,8 +601,10 @@ fn module(
                 () => {
                     let baseline = &ctxt.baseline;
                     quote!(
+                        // NOTE this field is visible so we use a shared reference to make it
+                        // immutable
                         #[doc(hidden)]
-                        pub #baseline: rtfm::Instant,
+                        pub #baseline: &'a rtfm::Instant,
                     )
                 }
                 #[cfg(not(feature = "timer-queue"))]
@@ -609,7 +617,7 @@ fn module(
                 pub struct Spawn<'a> {
                     #baseline_field
                     #[doc(hidden)]
-                    pub #priority: &'a core::cell::Cell<u8>,
+                    pub #priority: &'a rtfm::export::Priority,
                 }
             ));
         }
@@ -691,7 +699,7 @@ fn prelude(
         let mut exprs = vec![];
 
         // NOTE This field is just to avoid unused type parameter errors around `'a`
-        defs.push(quote!(#[allow(dead_code)] #priority: &'a core::cell::Cell<u8>));
+        defs.push(quote!(#[allow(dead_code)] pub #priority: &'a rtfm::export::Priority));
         exprs.push(parse_quote!(#priority));
 
         let mut may_call_lock = false;
@@ -830,7 +838,8 @@ fn prelude(
                                     #(#cfgs)*
                                     pub #name: &'a #mut_ #name
                                 ));
-                                let alias = ctxt.ident_gen.mk_ident(None);
+                                // XXX is randomness required?
+                                let alias = ctxt.ident_gen.mk_ident(None, true);
                                 items.push(quote!(
                                     #(#cfgs)*
                                     let #mut_ #alias = unsafe {
@@ -847,7 +856,8 @@ fn prelude(
                                     #(#cfgs)*
                                     pub #name: rtfm::Exclusive<'a, #name>
                                 ));
-                                let alias = ctxt.ident_gen.mk_ident(None);
+                                // XXX is randomness required?
+                                let alias = ctxt.ident_gen.mk_ident(None, true);
                                 items.push(quote!(
                                     #(#cfgs)*
                                     let #mut_ #alias = unsafe {
@@ -914,7 +924,7 @@ fn prelude(
             }
         }
 
-        let alias = ctxt.ident_gen.mk_ident(None);
+        let alias = ctxt.ident_gen.mk_ident(None, false);
         let unsafety = if needs_unsafe {
             Some(quote!(unsafe))
         } else {
@@ -975,7 +985,8 @@ fn prelude(
                 continue;
             }
 
-            ctxt.schedule_fn.insert(task.clone(), ctxt.ident_gen.mk_ident(None));
+            ctxt.schedule_fn
+                .insert(task.clone(), ctxt.ident_gen.mk_ident(None, false));
         }
 
         items.push(quote!(
@@ -991,7 +1002,7 @@ fn prelude(
         quote!()
     } else {
         quote!(
-            let ref #priority = core::cell::Cell::new(#logical_prio);
+            let ref #priority = unsafe { rtfm::export::Priority::new(#logical_prio) };
 
             #(#items)*
         )
@@ -1035,13 +1046,19 @@ fn idle(
             quote!(
                 #module
 
+                // unsafe trampoline to deter end-users from calling this non-reentrant function
                 #(#attrs)*
-                #unsafety fn #idle() -> ! {
-                    #(#locals)*
+                unsafe fn #idle() -> ! {
+                    #[inline(always)]
+                    #unsafety fn idle() -> ! {
+                        #(#locals)*
 
-                    #prelude
+                        #prelude
 
-                    #(#stmts)*
+                        #(#stmts)*
+                    }
+
+                    idle()
                 }
             ),
             quote!(#idle()),
@@ -1087,7 +1104,7 @@ fn exceptions(ctxt: &mut Context, app: &App, analysis: &Analysis) -> Vec<proc_ma
             let baseline = &ctxt.baseline;
             let baseline_let = match () {
                 #[cfg(feature = "timer-queue")]
-                () => quote!(let #baseline = rtfm::Instant::now();),
+                () => quote!(let ref #baseline = rtfm::Instant::now();),
                 #[cfg(not(feature = "timer-queue"))]
                 () => quote!(),
             };
@@ -1096,7 +1113,7 @@ fn exceptions(ctxt: &mut Context, app: &App, analysis: &Analysis) -> Vec<proc_ma
                 #[cfg(feature = "timer-queue")]
                 () => quote!(
                     #[allow(unused_variables)]
-                    let start = #baseline;
+                    let start = *#baseline;
                 ),
                 #[cfg(not(feature = "timer-queue"))]
                 () => quote!(),
@@ -1104,26 +1121,31 @@ fn exceptions(ctxt: &mut Context, app: &App, analysis: &Analysis) -> Vec<proc_ma
 
             let locals = mk_locals(&exception.statics, false);
             let symbol = ident.to_string();
-            let alias = ctxt.ident_gen.mk_ident(None);
+            let alias = ctxt.ident_gen.mk_ident(None, false);
             let unsafety = &exception.unsafety;
             quote!(
                 #module
 
-                #[doc(hidden)]
+                // unsafe trampoline to deter end-users from calling this non-reentrant function
                 #[export_name = #symbol]
                 #(#attrs)*
-                #unsafety fn #alias() {
-                    #(#locals)*
+                unsafe fn #alias() {
+                    #[inline(always)]
+                    #unsafety fn exception() {
+                        #(#locals)*
 
-                    #baseline_let
+                        #baseline_let
 
-                    #prelude
+                        #prelude
 
-                    #start_let
+                        #start_let
 
-                    rtfm::export::run(move || {
-                        #(#stmts)*
-                    })
+                        rtfm::export::run(move || {
+                            #(#stmts)*
+                        })
+                    }
+
+                    exception()
                 }
             )
         })
@@ -1167,7 +1189,7 @@ fn interrupts(
         let baseline = &ctxt.baseline;
         let baseline_let = match () {
             #[cfg(feature = "timer-queue")]
-            () => quote!(let #baseline = rtfm::Instant::now();),
+            () => quote!(let ref #baseline = rtfm::Instant::now();),
             #[cfg(not(feature = "timer-queue"))]
             () => quote!(),
         };
@@ -1176,34 +1198,40 @@ fn interrupts(
             #[cfg(feature = "timer-queue")]
             () => quote!(
                 #[allow(unused_variables)]
-                let start = #baseline;
+                let start = *#baseline;
             ),
             #[cfg(not(feature = "timer-queue"))]
             () => quote!(),
         };
 
         let locals = mk_locals(&interrupt.statics, false);
-        let alias = ctxt.ident_gen.mk_ident(None);
+        let alias = ctxt.ident_gen.mk_ident(None, false);
         let symbol = ident.to_string();
         let unsafety = &interrupt.unsafety;
         scoped.push(quote!(
+            // unsafe trampoline to deter end-users from calling this non-reentrant function
             #(#attrs)*
             #[export_name = #symbol]
-            #unsafety fn #alias() {
-                // check that this interrupt exists
-                let _ = #device::interrupt::#ident;
+            unsafe fn #alias() {
+                #[inline(always)]
+                #unsafety fn interrupt() {
+                    // check that this interrupt exists
+                    let _ = #device::interrupt::#ident;
 
-                #(#locals)*
+                    #(#locals)*
 
-                #baseline_let
+                    #baseline_let
 
-                #prelude
+                    #prelude
 
-                #start_let
+                    #start_let
 
-                rtfm::export::run(move || {
-                    #(#stmts)*
-                })
+                    rtfm::export::run(move || {
+                        #(#stmts)*
+                    })
+                }
+
+                interrupt()
             }
         ));
     }
@@ -1217,10 +1245,10 @@ fn tasks(ctxt: &mut Context, app: &App, analysis: &Analysis) -> proc_macro2::Tok
     // first pass to generate buffers (statics and resources) and spawn aliases
     for (name, task) in &app.tasks {
         #[cfg(feature = "timer-queue")]
-        let scheduleds_alias = ctxt.ident_gen.mk_ident(None);
-        let free_alias = ctxt.ident_gen.mk_ident(None);
-        let inputs_alias = ctxt.ident_gen.mk_ident(None);
-        let task_alias = ctxt.ident_gen.mk_ident(Some(&name.to_string()));
+        let scheduleds_alias = ctxt.ident_gen.mk_ident(None, false);
+        let free_alias = ctxt.ident_gen.mk_ident(None, false);
+        let inputs_alias = ctxt.ident_gen.mk_ident(None, false);
+        let task_alias = ctxt.ident_gen.mk_ident(Some(&name.to_string()), false);
 
         let inputs = &task.inputs;
 
@@ -1281,7 +1309,7 @@ fn tasks(ctxt: &mut Context, app: &App, analysis: &Analysis) -> proc_macro2::Tok
                 alias: task_alias,
                 free_queue: free_alias,
                 inputs: inputs_alias,
-                spawn_fn: ctxt.ident_gen.mk_ident(None),
+                spawn_fn: ctxt.ident_gen.mk_ident(None, false),
 
                 #[cfg(feature = "timer-queue")]
                 scheduleds: scheduleds_alias,
@@ -1300,7 +1328,7 @@ fn tasks(ctxt: &mut Context, app: &App, analysis: &Analysis) -> proc_macro2::Tok
             #[cfg(feature = "timer-queue")]
             () => {
                 let baseline = &ctxt.baseline;
-                quote!(let scheduled = #baseline;)
+                quote!(let scheduled = *#baseline;)
             }
             #[cfg(not(feature = "timer-queue"))]
             () => quote!(),
@@ -1329,26 +1357,33 @@ fn tasks(ctxt: &mut Context, app: &App, analysis: &Analysis) -> proc_macro2::Tok
         let attrs = &task.attrs;
         let cfgs = &task.cfgs;
         let task_alias = &ctxt.tasks[name].alias;
-        let baseline_arg = match () {
+        let (baseline, baseline_arg) = match () {
             #[cfg(feature = "timer-queue")]
             () => {
                 let baseline = &ctxt.baseline;
-                quote!(#baseline: rtfm::Instant,)
+                (quote!(#baseline,), quote!(#baseline: &rtfm::Instant,))
             }
             #[cfg(not(feature = "timer-queue"))]
-            () => quote!(),
+            () => (quote!(), quote!()),
         };
+        let pats = tuple_pat(inputs);
         items.push(quote!(
+            // unsafe trampoline to deter end-users from calling this non-reentrant function
             #(#attrs)*
             #(#cfgs)*
-            #unsafety fn #task_alias(#baseline_arg #(#inputs,)*) {
-                #(#locals)*
+            unsafe fn #task_alias(#baseline_arg #(#inputs,)*) {
+                #[inline(always)]
+                #unsafety fn task(#baseline_arg #(#inputs,)*) {
+                    #(#locals)*
 
-                #prelude
+                    #prelude
 
-                #scheduled_let
+                    #scheduled_let
 
-                #(#stmts)*
+                    #(#stmts)*
+                }
+
+                task(#baseline #pats)
             }
         ));
     }
@@ -1366,8 +1401,8 @@ fn dispatchers(
 
     let device = &app.args.device;
     for (level, dispatcher) in &analysis.dispatchers {
-        let ready_alias = ctxt.ident_gen.mk_ident(None);
-        let enum_alias = ctxt.ident_gen.mk_ident(None);
+        let ready_alias = ctxt.ident_gen.mk_ident(None, false);
+        let enum_alias = ctxt.ident_gen.mk_ident(None, false);
         let capacity = mk_typenum_capacity(dispatcher.capacity, true);
 
         let variants = dispatcher
@@ -1431,7 +1466,7 @@ fn dispatchers(
                             let baseline =
                                 ptr::read(#scheduleds.get_ref().get_unchecked(usize::from(index)));
                         );
-                        call = quote!(#alias(baseline, #pats));
+                        call = quote!(#alias(&baseline, #pats));
                     }
                     #[cfg(not(feature = "timer-queue"))]
                     () => {
@@ -1456,7 +1491,7 @@ fn dispatchers(
         let attrs = &dispatcher.attrs;
         let interrupt = &dispatcher.interrupt;
         let symbol = interrupt.to_string();
-        let alias = ctxt.ident_gen.mk_ident(None);
+        let alias = ctxt.ident_gen.mk_ident(None, false);
         dispatchers.push(quote!(
             #(#attrs)*
             #[export_name = #symbol]
@@ -1538,7 +1573,7 @@ fn spawn(ctxt: &Context, app: &App, analysis: &Analysis) -> proc_macro2::TokenSt
             #(#cfgs)*
             unsafe fn #alias(
                 #baseline_arg
-                #priority: &core::cell::Cell<u8>,
+                #priority: &rtfm::export::Priority,
                 #(#args,)*
             ) -> Result<(), #ty> {
                 use core::ptr;
@@ -1587,7 +1622,7 @@ fn spawn(ctxt: &Context, app: &App, analysis: &Analysis) -> proc_macro2::TokenSt
                     if is_idle {
                         quote!(rtfm::Instant::now(),)
                     } else {
-                        quote!(self.#baseline,)
+                        quote!(*self.#baseline,)
                     }
                 }
                 #[cfg(not(feature = "timer-queue"))]
@@ -1636,7 +1671,7 @@ fn schedule(ctxt: &Context, app: &App) -> proc_macro2::TokenStream {
             #[inline(always)]
             #(#cfgs)*
             unsafe fn #alias(
-                #priority: &core::cell::Cell<u8>,
+                #priority: &rtfm::export::Priority,
                 instant: rtfm::Instant,
                 #(#args,)*
             ) -> Result<(), #ty> {
@@ -1782,14 +1817,14 @@ fn timer_queue(ctxt: &mut Context, app: &App, analysis: &Analysis) -> proc_macro
         .collect::<Vec<_>>();
 
     let logical_prio = analysis.timer_queue.priority;
-    let alias = ctxt.ident_gen.mk_ident(None);
+    let alias = ctxt.ident_gen.mk_ident(None, false);
     items.push(quote!(
         #[export_name = "SysTick"]
         #[doc(hidden)]
         unsafe fn #alias() {
             use rtfm::Mutex;
 
-            let ref #priority = core::cell::Cell::new(#logical_prio);
+            let ref #priority = rtfm::export::Priority::new(#logical_prio);
 
             rtfm::export::run(|| {
                 rtfm::export::sys_tick(#tq { #priority }, |task, index| {
@@ -1933,7 +1968,7 @@ fn mk_resource(
             #(#cfgs)*
             pub struct #struct_<'a> {
                 #[doc(hidden)]
-                pub #priority: &'a core::cell::Cell<u8>,
+                pub #priority: &'a rtfm::export::Priority,
             }
         ));
 
@@ -1942,7 +1977,7 @@ fn mk_resource(
         items.push(quote!(
             #(#cfgs)*
             struct #struct_<'a> {
-                #priority: &'a core::cell::Cell<u8>,
+                #priority: &'a rtfm::export::Priority,
             }
         ));
 
@@ -2017,34 +2052,30 @@ impl IdentGenerator {
 
         let rng = rand::rngs::SmallRng::from_seed(seed);
 
-        IdentGenerator {
-            call_count: 0,
-            rng,
-        }
+        IdentGenerator { call_count: 0, rng }
     }
 
-    fn mk_ident(&mut self, name: Option<&str>) -> Ident {
-        let n;
+    fn mk_ident(&mut self, name: Option<&str>, random: bool) -> Ident {
         let s = if let Some(name) = name {
-            n = 4;
             format!("{}_", name)
         } else {
-            let crate_name = env!("CARGO_PKG_NAME").replace("-", "_").to_lowercase();
-            n = 4;
-            format!("{}__internal__", crate_name)
+            "__rtfm_internal_".to_string()
         };
 
-        let mut s = format!("{}{}_", s, self.call_count);
+        let mut s = format!("{}{}", s, self.call_count);
+        self.call_count += 1;
 
-        for i in 0..n {
-            if i == 0 || self.rng.gen() {
-                s.push(('a' as u8 + self.rng.gen::<u8>() % 25) as char)
-            } else {
-                s.push(('0' as u8 + self.rng.gen::<u8>() % 10) as char)
+        if random {
+            s.push('_');
+
+            for i in 0..4 {
+                if i == 0 || self.rng.gen() {
+                    s.push(('a' as u8 + self.rng.gen::<u8>() % 25) as char)
+                } else {
+                    s.push(('0' as u8 + self.rng.gen::<u8>() % 10) as char)
+                }
             }
         }
-
-        self.call_count += 1;
 
         Ident::new(&s, Span::call_site())
     }

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -1998,7 +1998,12 @@ struct IdentGenerator {
 
 impl IdentGenerator {
     fn new() -> IdentGenerator {
-        IdentGenerator { rng: rand::rngs::SmallRng::seed_from_u64(0) }
+        let crate_name = env!("CARGO_PKG_NAME");
+        let seed = [0u8; 16];
+        for (i, b) in crate_name.bytes().enumerate() {
+            seed[i%seed.len()].wrapping_add(b);
+        }
+        IdentGenerator { rng: rand::rngs::SmallRng::from_seed(seed) }
     }
 
     fn mk_ident(&mut self, name: Option<&str>) -> Ident {
@@ -2007,8 +2012,9 @@ impl IdentGenerator {
             n = 4;
             format!("{}_", name)
         } else {
+            let crate_name = env!("CARGO_PKG_NAME").replace("-", "_").to_lowercase();
             n = 16;
-            String::new()
+            format!("{}__internal__", crate_name)
         };
 
         for i in 0..n {

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -3,8 +3,6 @@
 use proc_macro::TokenStream;
 use std::{
     collections::{BTreeMap, HashMap},
-    sync::atomic::{AtomicUsize, Ordering},
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 use proc_macro2::Span;
@@ -44,6 +42,8 @@ struct Context {
     tasks: BTreeMap<Ident, Task>,
     // Alias (`struct` / `static mut`)
     timer_queue: Ident,
+    // Generator of Ident names or suffixes
+    ident_gen: IdentGenerator,
 }
 
 struct Dispatcher {
@@ -63,19 +63,22 @@ struct Task {
 
 impl Default for Context {
     fn default() -> Self {
+        let mut ident_gen = IdentGenerator::new();
+
         Context {
             #[cfg(feature = "timer-queue")]
-            baseline: mk_ident(None),
+            baseline: ident_gen.mk_ident(None),
             dispatchers: BTreeMap::new(),
-            idle: mk_ident(Some("idle")),
-            init: mk_ident(Some("init")),
-            priority: mk_ident(None),
+            idle: ident_gen.mk_ident(Some("idle")),
+            init: ident_gen.mk_ident(Some("init")),
+            priority: ident_gen.mk_ident(None),
             statics: Aliases::new(),
             resources: HashMap::new(),
-            schedule_enum: mk_ident(None),
+            schedule_enum: ident_gen.mk_ident(None),
             schedule_fn: Aliases::new(),
             tasks: BTreeMap::new(),
-            timer_queue: mk_ident(None),
+            timer_queue: ident_gen.mk_ident(None),
+            ident_gen,
         }
     }
 }
@@ -164,13 +167,13 @@ pub fn app(app: &App, analysis: &Analysis) -> TokenStream {
         () => quote!(),
     };
 
-    let timer_queue = timer_queue(&ctxt, app, analysis);
+    let timer_queue = timer_queue(&mut ctxt, app, analysis);
 
     let pre_init = pre_init(&ctxt, &app, analysis);
 
     let assertions = assertions(app, analysis);
 
-    let main = mk_ident(None);
+    let main = ctxt.ident_gen.mk_ident(None);
     quote!(
         #resources
 
@@ -236,7 +239,7 @@ fn resources(ctxt: &mut Context, app: &App, analysis: &Analysis) -> proc_macro2:
                 pub static #mut_ #name: #ty = #expr;
             ));
 
-            let alias = mk_ident(None);
+            let alias = ctxt.ident_gen.mk_ident(None);
             if let Some(Ownership::Shared { ceiling }) = analysis.ownerships.get(name) {
                 items.push(mk_resource(
                     ctxt,
@@ -252,7 +255,7 @@ fn resources(ctxt: &mut Context, app: &App, analysis: &Analysis) -> proc_macro2:
 
             ctxt.statics.insert(name.clone(), alias);
         } else {
-            let alias = mk_ident(None);
+            let alias = ctxt.ident_gen.mk_ident(None);
             let symbol = format!("{}::{}", name, alias);
 
             items.push(
@@ -826,7 +829,7 @@ fn prelude(
                                     #(#cfgs)*
                                     pub #name: &'a #mut_ #name
                                 ));
-                                let alias = mk_ident(None);
+                                let alias = ctxt.ident_gen.mk_ident(None);
                                 items.push(quote!(
                                     #(#cfgs)*
                                     let #mut_ #alias = unsafe {
@@ -843,7 +846,7 @@ fn prelude(
                                     #(#cfgs)*
                                     pub #name: rtfm::Exclusive<'a, #name>
                                 ));
-                                let alias = mk_ident(None);
+                                let alias = ctxt.ident_gen.mk_ident(None);
                                 items.push(quote!(
                                     #(#cfgs)*
                                     let #mut_ #alias = unsafe {
@@ -910,7 +913,7 @@ fn prelude(
             }
         }
 
-        let alias = mk_ident(None);
+        let alias = ctxt.ident_gen.mk_ident(None);
         let unsafety = if needs_unsafe {
             Some(quote!(unsafe))
         } else {
@@ -971,7 +974,7 @@ fn prelude(
                 continue;
             }
 
-            ctxt.schedule_fn.insert(task.clone(), mk_ident(None));
+            ctxt.schedule_fn.insert(task.clone(), ctxt.ident_gen.mk_ident(None));
         }
 
         items.push(quote!(
@@ -1100,7 +1103,7 @@ fn exceptions(ctxt: &mut Context, app: &App, analysis: &Analysis) -> Vec<proc_ma
 
             let locals = mk_locals(&exception.statics, false);
             let symbol = ident.to_string();
-            let alias = mk_ident(None);
+            let alias = ctxt.ident_gen.mk_ident(None);
             let unsafety = &exception.unsafety;
             quote!(
                 #module
@@ -1179,7 +1182,7 @@ fn interrupts(
         };
 
         let locals = mk_locals(&interrupt.statics, false);
-        let alias = mk_ident(None);
+        let alias = ctxt.ident_gen.mk_ident(None);
         let symbol = ident.to_string();
         let unsafety = &interrupt.unsafety;
         scoped.push(quote!(
@@ -1213,10 +1216,10 @@ fn tasks(ctxt: &mut Context, app: &App, analysis: &Analysis) -> proc_macro2::Tok
     // first pass to generate buffers (statics and resources) and spawn aliases
     for (name, task) in &app.tasks {
         #[cfg(feature = "timer-queue")]
-        let scheduleds_alias = mk_ident(None);
-        let free_alias = mk_ident(None);
-        let inputs_alias = mk_ident(None);
-        let task_alias = mk_ident(Some(&name.to_string()));
+        let scheduleds_alias = ctxt.ident_gen.mk_ident(None);
+        let free_alias = ctxt.ident_gen.mk_ident(None);
+        let inputs_alias = ctxt.ident_gen.mk_ident(None);
+        let task_alias = ctxt.ident_gen.mk_ident(Some(&name.to_string()));
 
         let inputs = &task.inputs;
 
@@ -1277,7 +1280,7 @@ fn tasks(ctxt: &mut Context, app: &App, analysis: &Analysis) -> proc_macro2::Tok
                 alias: task_alias,
                 free_queue: free_alias,
                 inputs: inputs_alias,
-                spawn_fn: mk_ident(None),
+                spawn_fn: ctxt.ident_gen.mk_ident(None),
 
                 #[cfg(feature = "timer-queue")]
                 scheduleds: scheduleds_alias,
@@ -1362,8 +1365,8 @@ fn dispatchers(
 
     let device = &app.args.device;
     for (level, dispatcher) in &analysis.dispatchers {
-        let ready_alias = mk_ident(None);
-        let enum_alias = mk_ident(None);
+        let ready_alias = ctxt.ident_gen.mk_ident(None);
+        let enum_alias = ctxt.ident_gen.mk_ident(None);
         let capacity = mk_typenum_capacity(dispatcher.capacity, true);
 
         let variants = dispatcher
@@ -1452,7 +1455,7 @@ fn dispatchers(
         let attrs = &dispatcher.attrs;
         let interrupt = &dispatcher.interrupt;
         let symbol = interrupt.to_string();
-        let alias = mk_ident(None);
+        let alias = ctxt.ident_gen.mk_ident(None);
         dispatchers.push(quote!(
             #(#attrs)*
             #[export_name = #symbol]
@@ -1703,7 +1706,7 @@ fn schedule(ctxt: &Context, app: &App) -> proc_macro2::TokenStream {
     quote!(#(#items)*)
 }
 
-fn timer_queue(ctxt: &Context, app: &App, analysis: &Analysis) -> proc_macro2::TokenStream {
+fn timer_queue(ctxt: &mut Context, app: &App, analysis: &Analysis) -> proc_macro2::TokenStream {
     let tasks = &analysis.timer_queue.tasks;
 
     if tasks.is_empty() {
@@ -1778,7 +1781,7 @@ fn timer_queue(ctxt: &Context, app: &App, analysis: &Analysis) -> proc_macro2::T
         .collect::<Vec<_>>();
 
     let logical_prio = analysis.timer_queue.priority;
-    let alias = mk_ident(None);
+    let alias = ctxt.ident_gen.mk_ident(None);
     items.push(quote!(
         #[export_name = "SysTick"]
         #[doc(hidden)]
@@ -1989,48 +1992,35 @@ fn mk_typenum_capacity(capacity: u8, power_of_two: bool) -> proc_macro2::TokenSt
     quote!(rtfm::export::consts::#ident)
 }
 
-fn mk_ident(name: Option<&str>) -> Ident {
-    static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+struct IdentGenerator {
+    rng: rand::rngs::SmallRng,
+}
 
-    let elapsed = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-
-    let secs = elapsed.as_secs();
-    let nanos = elapsed.subsec_nanos();
-
-    let count = CALL_COUNT.fetch_add(1, Ordering::SeqCst) as u32;
-    let mut seed: [u8; 16] = [0; 16];
-
-    for (i, v) in seed.iter_mut().take(8).enumerate() {
-        *v = ((secs >> (i * 8)) & 0xFF) as u8
+impl IdentGenerator {
+    fn new() -> IdentGenerator {
+        IdentGenerator { rng: rand::rngs::SmallRng::seed_from_u64(0) }
     }
 
-    for (i, v) in seed.iter_mut().skip(8).take(4).enumerate() {
-        *v = ((nanos >> (i * 8)) & 0xFF) as u8
-    }
-
-    for (i, v) in seed.iter_mut().skip(12).enumerate() {
-        *v = ((count >> (i * 8)) & 0xFF) as u8
-    }
-
-    let n;
-    let mut s = if let Some(name) = name {
-        n = 4;
-        format!("{}_", name)
-    } else {
-        n = 16;
-        String::new()
-    };
-
-    let mut rng = rand::rngs::SmallRng::from_seed(seed);
-    for i in 0..n {
-        if i == 0 || rng.gen() {
-            s.push(('a' as u8 + rng.gen::<u8>() % 25) as char)
+    fn mk_ident(&mut self, name: Option<&str>) -> Ident {
+        let n;
+        let mut s = if let Some(name) = name {
+            n = 4;
+            format!("{}_", name)
         } else {
-            s.push(('0' as u8 + rng.gen::<u8>() % 10) as char)
-        }
-    }
+            n = 16;
+            String::new()
+        };
 
-    Ident::new(&s, Span::call_site())
+        for i in 0..n {
+            if i == 0 || self.rng.gen() {
+                s.push(('a' as u8 + self.rng.gen::<u8>() % 25) as char)
+            } else {
+                s.push(('0' as u8 + self.rng.gen::<u8>() % 10) as char)
+            }
+        }
+
+        Ident::new(&s, Span::call_site())
+    }
 }
 
 // `once = true` means that these locals will be called from a function that will run *once*

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -2,7 +2,7 @@
 
 use proc_macro::TokenStream;
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     sync::atomic::{AtomicUsize, Ordering},
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -20,13 +20,13 @@ use crate::{
 // NOTE to avoid polluting the user namespaces we map some identifiers to pseudo-hygienic names.
 // In some instances we also use the pseudo-hygienic names for safety, for example the user should
 // not modify the priority field of resources.
-type Aliases = HashMap<Ident, Ident>;
+type Aliases = BTreeMap<Ident, Ident>;
 
 struct Context {
     // Alias
     #[cfg(feature = "timer-queue")]
     baseline: Ident,
-    dispatchers: HashMap<u8, Dispatcher>,
+    dispatchers: BTreeMap<u8, Dispatcher>,
     // Alias (`fn`)
     idle: Ident,
     // Alias (`fn`)
@@ -41,7 +41,7 @@ struct Context {
     schedule_enum: Ident,
     // Task -> Alias (`fn`)
     schedule_fn: Aliases,
-    tasks: HashMap<Ident, Task>,
+    tasks: BTreeMap<Ident, Task>,
     // Alias (`struct` / `static mut`)
     timer_queue: Ident,
 }
@@ -66,7 +66,7 @@ impl Default for Context {
         Context {
             #[cfg(feature = "timer-queue")]
             baseline: mk_ident(None),
-            dispatchers: HashMap::new(),
+            dispatchers: BTreeMap::new(),
             idle: mk_ident(Some("idle")),
             init: mk_ident(Some("init")),
             priority: mk_ident(None),
@@ -74,7 +74,7 @@ impl Default for Context {
             resources: HashMap::new(),
             schedule_enum: mk_ident(None),
             schedule_fn: Aliases::new(),
-            tasks: HashMap::new(),
+            tasks: BTreeMap::new(),
             timer_queue: mk_ident(None),
         }
     }
@@ -2034,7 +2034,7 @@ fn mk_ident(name: Option<&str>) -> Ident {
 }
 
 // `once = true` means that these locals will be called from a function that will run *once*
-fn mk_locals(locals: &HashMap<Ident, Static>, once: bool) -> proc_macro2::TokenStream {
+fn mk_locals(locals: &BTreeMap<Ident, Static>, once: bool) -> proc_macro2::TokenStream {
     let lt = if once { Some(quote!('static)) } else { None };
 
     let locals = locals

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -364,7 +364,7 @@ fn init(ctxt: &mut Context, app: &App, analysis: &Analysis) -> (proc_macro2::Tok
 
     let (late_resources, late_resources_ident, ret) = if app.init.returns_late_resources {
         // create `LateResources` struct in the root of the crate
-        let ident = mk_ident(None);
+        let ident = ctxt.ident_gen.mk_ident(None, false);
 
         let fields = app
             .resources

--- a/macros/src/syntax.rs
+++ b/macros/src/syntax.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet},
     iter, u8,
 };
 
@@ -120,10 +120,10 @@ impl App {
     pub fn parse(items: Vec<Item>, args: AppArgs) -> parse::Result<Self> {
         let mut idle = None;
         let mut init = None;
-        let mut exceptions = HashMap::new();
-        let mut interrupts = HashMap::new();
-        let mut resources = HashMap::new();
-        let mut tasks = HashMap::new();
+        let mut exceptions = BTreeMap::new();
+        let mut interrupts = BTreeMap::new();
+        let mut resources = BTreeMap::new();
+        let mut tasks = BTreeMap::new();
         let mut free_interrupts = None;
 
         for item in items {
@@ -418,25 +418,25 @@ impl App {
     }
 }
 
-pub type Idents = HashSet<Ident>;
+pub type Idents = BTreeSet<Ident>;
 
-pub type Exceptions = HashMap<Ident, Exception>;
+pub type Exceptions = BTreeMap<Ident, Exception>;
 
-pub type Interrupts = HashMap<Ident, Interrupt>;
+pub type Interrupts = BTreeMap<Ident, Interrupt>;
 
-pub type Resources = HashMap<Ident, Resource>;
+pub type Resources = BTreeMap<Ident, Resource>;
 
 pub type Statics = Vec<ItemStatic>;
 
-pub type Tasks = HashMap<Ident, Task>;
+pub type Tasks = BTreeMap<Ident, Task>;
 
-pub type FreeInterrupts = HashMap<Ident, FreeInterrupt>;
+pub type FreeInterrupts = BTreeMap<Ident, FreeInterrupt>;
 
 pub struct Idle {
     pub args: IdleArgs,
     pub attrs: Vec<Attribute>,
     pub unsafety: Option<Token![unsafe]>,
-    pub statics: HashMap<Ident, Static>,
+    pub statics: BTreeMap<Ident, Static>,
     pub stmts: Vec<Stmt>,
 }
 
@@ -607,7 +607,7 @@ pub struct Init {
     pub args: InitArgs,
     pub attrs: Vec<Attribute>,
     pub unsafety: Option<Token![unsafe]>,
-    pub statics: HashMap<Ident, Static>,
+    pub statics: BTreeMap<Ident, Static>,
     pub stmts: Vec<Stmt>,
     // TODO remove in v0.5.x
     pub assigns: Vec<Assign>,
@@ -703,7 +703,7 @@ pub struct Exception {
     pub args: ExceptionArgs,
     pub attrs: Vec<Attribute>,
     pub unsafety: Option<Token![unsafe]>,
-    pub statics: HashMap<Ident, Static>,
+    pub statics: BTreeMap<Ident, Static>,
     pub stmts: Vec<Stmt>,
 }
 
@@ -791,7 +791,7 @@ pub struct Interrupt {
     pub args: InterruptArgs,
     pub attrs: Vec<Attribute>,
     pub unsafety: Option<Token![unsafe]>,
-    pub statics: HashMap<Ident, Static>,
+    pub statics: BTreeMap<Ident, Static>,
     pub stmts: Vec<Stmt>,
 }
 
@@ -1070,8 +1070,8 @@ pub struct Static {
 }
 
 impl Static {
-    fn parse(items: Vec<ItemStatic>) -> parse::Result<HashMap<Ident, Static>> {
-        let mut statics = HashMap::new();
+    fn parse(items: Vec<ItemStatic>) -> parse::Result<BTreeMap<Ident, Static>> {
+        let mut statics = BTreeMap::new();
 
         for item in items {
             if statics.contains_key(&item.ident) {
@@ -1104,7 +1104,7 @@ pub struct Task {
     pub attrs: Vec<Attribute>,
     pub unsafety: Option<Token![unsafe]>,
     pub inputs: Vec<ArgCaptured>,
-    pub statics: HashMap<Ident, Static>,
+    pub statics: BTreeMap<Ident, Static>,
     pub stmts: Vec<Stmt>,
 }
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -47,7 +47,9 @@ pub struct Priority {
 impl Priority {
     #[inline(always)]
     pub unsafe fn new(value: u8) -> Self {
-        Priority { inner: Cell::new(value)}
+        Priority {
+            inner: Cell::new(value),
+        }
     }
 
     // these two methods are used by claim (see below) but can't be used from the RTFM application

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -38,18 +38,16 @@ fn cfail() {
         let f = f.unwrap().path();
         let name = f.file_stem().unwrap().to_str().unwrap();
 
-        assert!(
-            Command::new("rustc")
-                .args(s.split_whitespace())
-                .arg(f.display().to_string())
-                .arg("-o")
-                .arg(td.path().join(name).display().to_string())
-                .arg("-C")
-                .arg("linker=true")
-                .status()
-                .unwrap()
-                .success()
-        );
+        assert!(Command::new("rustc")
+            .args(s.split_whitespace())
+            .arg(f.display().to_string())
+            .arg("-o")
+            .arg(td.path().join(name).display().to_string())
+            .arg("-C")
+            .arg("linker=true")
+            .status()
+            .unwrap()
+            .success());
     }
 
     config.target_rustcflags = Some(s);


### PR DESCRIPTION
This is a rebased and augmented version of #132. With this PR both dev and release builds that do not use the owned-singleton stuff become reproducible. (I haven't really bothered to make owned-singleton reproducible since [lifo] is way more ergonomic than [alloc-singleton] and will eventually make its way into heapless).

[lifo]: https://github.com/japaric/lifo
[alloc-singleton]: https://crates.io/crates/alloc-singleton

Thanks @hugwijst for doing the bulk of the work!

closes #132