### PR TITLE
add "nightly" feature; replace hint::unreachable_unchecked with a panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ features = ["exit"]
 version = "0.5.1"
 
 [features]
+nightly = ["cortex-m-rtfm-macros/nightly", "heapless/const-fn"]
 timer-queue = ["cortex-m-rtfm-macros/timer-queue"]
 
 [target.x86_64-unknown-linux-gnu.dev-dependencies]

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -146,18 +146,22 @@ main() {
 
                 if [ $ex != types ]; then
                     arm_example "build" $ex "debug" "$nightly" "2"
-                    cmp ci/builds/${ex}_debug_1.hex ci/builds/${ex}_debug_2.hex
+                    cmp ci/builds/${ex}_${nightly/nightly/nightly_}debug_1.hex \
+                        ci/builds/${ex}_${nightly/nightly/nightly_}debug_2.hex
                     arm_example "build" $ex "release" "$nightly" "2"
-                    cmp ci/builds/${ex}_release_1.hex ci/builds/${ex}_release_2.hex
+                    cmp ci/builds/${ex}_${nightly/nightly/nightly_}release_1.hex \
+                        ci/builds/${ex}_${nightly/nightly/nightly_}release_2.hex
 
                     built+=( $ex )
                 fi
 
                 if [ $TARGET != thumbv6m-none-eabi ]; then
                     arm_example "build" $ex "debug" "$nightly,timer-queue" "2"
-                    cmp ci/builds/${ex}_timer-queue_debug_1.hex ci/builds/${ex}_timer-queue_debug_2.hex
+                    cmp ci/builds/${ex}_${nightly}_timer-queue_debug_1.hex \
+                        ci/builds/${ex}_${nightly}_timer-queue_debug_2.hex
                     arm_example "build" $ex "release" "$nightly,timer-queue" "2"
-                    cmp ci/builds/${ex}_timer-queue_release_1.hex ci/builds/${ex}_timer-queue_release_2.hex
+                    cmp ci/builds/${ex}_${nightly}_timer-queue_release_1.hex \
+                        ci/builds/${ex}_${nightly}_timer-queue_release_2.hex
                 fi
             done
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -33,6 +33,11 @@ arm_example() {
 
 main() {
     local T=$TARGET
+    local nightly=""
+
+    if [ $TRAVIS_RUST_VERSION = nightly ]; then
+        nightly="nightly"
+    fi
 
     mkdir -p ci/builds
 
@@ -41,12 +46,12 @@ main() {
         case $TRAVIS_RUST_VERSION in
             nightly*)
                 # TODO how to run a subset of these tests when timer-queue is disabled?
-                cargo test --features timer-queue --test compiletest --target $T
+                cargo test --features "$nightly,timer-queue" --test compiletest --target $T
         esac
 
         cargo check --target $T
         if [ $TARGET != thumbv6m-none-eabi ]; then
-            cargo check --features timer-queue --target $T
+            cargo check --features "$nightly,timer-queue" --target $T
         fi
 
         if [ $TRAVIS_RUST_VERSION != nightly ]; then
@@ -76,9 +81,9 @@ main() {
         return
     fi
 
-    cargo check --target $T --examples
+    cargo check --features "$nightly" --target $T --examples
     if [ $TARGET != thumbv6m-none-eabi ]; then
-        cargo check --features timer-queue --target $T --examples
+        cargo check --features "$nightly,timer-queue" --target $T --examples
     fi
 
     # run-pass tests
@@ -115,13 +120,13 @@ main() {
                 fi
 
                 if [ $ex != types ]; then
-                    arm_example "run" $ex "debug" "" "1"
-                    arm_example "run" $ex "release" "" "1"
+                    arm_example "run" $ex "debug" "$nightly" "1"
+                    arm_example "run" $ex "release" "$nightly" "1"
                 fi
 
                 if [ $TARGET != thumbv6m-none-eabi ]; then
-                    arm_example "run" $ex "debug" "timer-queue" "1"
-                    arm_example "run" $ex "release" "timer-queue" "1"
+                    arm_example "run" $ex "debug" "$nightly,timer-queue" "1"
+                    arm_example "run" $ex "release" "$nightly,timer-queue" "1"
                 fi
             done
 
@@ -139,16 +144,16 @@ main() {
                 fi
 
                 if [ $ex != types ]; then
-                    arm_example "build" $ex "debug" "" "2"
+                    arm_example "build" $ex "debug" "$nightly" "2"
                     cmp ci/builds/${ex}_debug_1.hex ci/builds/${ex}_debug_2.hex
-                    arm_example "build" $ex "release" "" "2"
+                    arm_example "build" $ex "release" "$nightly" "2"
                     cmp ci/builds/${ex}_release_1.hex ci/builds/${ex}_release_2.hex
                 fi
 
                 if [ $TARGET != thumbv6m-none-eabi ]; then
-                    arm_example "build" $ex "debug" "timer-queue" "2"
+                    arm_example "build" $ex "debug" "$nightly,timer-queue" "2"
                     cmp ci/builds/${ex}_timer-queue_debug_1.hex ci/builds/${ex}_timer-queue_debug_2.hex
-                    arm_example "build" $ex "release" "timer-queue" "2"
+                    arm_example "build" $ex "release" "$nightly,timer-queue" "2"
                     cmp ci/builds/${ex}_timer-queue_release_1.hex ci/builds/${ex}_timer-queue_release_2.hex
                 fi
             done

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -130,6 +130,7 @@ main() {
                 fi
             done
 
+            local built=()
             cargo clean
             for ex in ${exs[@]}; do
                 if [ $ex = ramfunc ] && [ $T = thumbv6m-none-eabi ]; then
@@ -148,6 +149,8 @@ main() {
                     cmp ci/builds/${ex}_debug_1.hex ci/builds/${ex}_debug_2.hex
                     arm_example "build" $ex "release" "$nightly" "2"
                     cmp ci/builds/${ex}_release_1.hex ci/builds/${ex}_release_2.hex
+
+                    built+=( $ex )
                 fi
 
                 if [ $TARGET != thumbv6m-none-eabi ]; then
@@ -157,6 +160,8 @@ main() {
                     cmp ci/builds/${ex}_timer-queue_release_1.hex ci/builds/${ex}_timer-queue_release_2.hex
                 fi
             done
+
+            ( cd target/$TARGET/release/examples/ && size ${built[@]} )
     esac
 }
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -28,3 +28,4 @@ version = "0.5.5"
 
 [features]
 timer-queue = []
+nightly = []

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,7 +1,5 @@
 //! IMPLEMENTATION DETAILS. DO NOT USE ANYTHING IN THIS MODULE
 
-#[cfg(all(not(feature = "nightly"), not(debug_assertions)))]
-use core::hint;
 #[cfg(not(feature = "nightly"))]
 use core::ptr;
 use core::{cell::Cell, u8};
@@ -99,6 +97,10 @@ pub struct MaybeUninit<T> {
 }
 
 #[cfg(not(feature = "nightly"))]
+const MSG: &str =
+    "you have hit a bug (UB) in RTFM implementation; try enabling this crate 'nightly' feature";
+
+#[cfg(not(feature = "nightly"))]
 impl<T> MaybeUninit<T> {
     pub const fn uninitialized() -> Self {
         MaybeUninit { value: None }
@@ -108,13 +110,7 @@ impl<T> MaybeUninit<T> {
         if let Some(x) = self.value.as_ref() {
             x
         } else {
-            match () {
-                // Try to catch UB when compiling in release with debug assertions enabled
-                #[cfg(debug_assertions)]
-                () => unreachable!(),
-                #[cfg(not(debug_assertions))]
-                () => unsafe { hint::unreachable_unchecked() },
-            }
+            unreachable!(MSG)
         }
     }
 
@@ -122,13 +118,7 @@ impl<T> MaybeUninit<T> {
         if let Some(x) = self.value.as_mut() {
             x
         } else {
-            match () {
-                // Try to catch UB when compiling in release with debug assertions enabled
-                #[cfg(debug_assertions)]
-                () => unreachable!(),
-                #[cfg(not(debug_assertions))]
-                () => unsafe { hint::unreachable_unchecked() },
-            }
+            unreachable!(MSG)
         }
     }
 
@@ -136,13 +126,7 @@ impl<T> MaybeUninit<T> {
         if let Some(x) = self.value.as_ref() {
             x
         } else {
-            match () {
-                // Try to catch UB when compiling in release with debug assertions enabled
-                #[cfg(debug_assertions)]
-                () => unreachable!(),
-                #[cfg(not(debug_assertions))]
-                () => hint::unreachable_unchecked(),
-            }
+            unreachable!(MSG)
         }
     }
 
@@ -150,13 +134,7 @@ impl<T> MaybeUninit<T> {
         if let Some(x) = self.value.as_mut() {
             x
         } else {
-            match () {
-                // Try to catch UB when compiling in release with debug assertions enabled
-                #[cfg(debug_assertions)]
-                () => unreachable!(),
-                #[cfg(not(debug_assertions))]
-                () => hint::unreachable_unchecked(),
-            }
+            unreachable!(MSG)
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,11 @@
 //!
 //! [`Instant`]: struct.Instant.html
 //! [`Duration`]: struct.Duration.html
+//!
+//! - `nightly`. Enabling this opt-in feature makes RTFM internally use the unstable
+//! `core::mem::MaybeUninit` API and unstable `const_fn` language feature to reduce static memory
+//! usage, runtime overhead and initialization overhead. This feature requires a nightly compiler
+//! and may stop working at any time!
 
 #![cfg_attr(feature = "nightly", feature(maybe_uninit))]
 #![deny(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@
 //! [`Instant`]: struct.Instant.html
 //! [`Duration`]: struct.Duration.html
 
+#![cfg_attr(feature = "nightly", feature(maybe_uninit))]
 #![deny(missing_docs)]
 #![deny(warnings)]
 #![no_std]


### PR DESCRIPTION
this implements the action plan described in #149

to give you a sense of the overhead of this change: it has increased the binary
size of some of our examples by up to 10% but this is mainly from pulling in a
panic handler that does formatting

r? @korken89