### PR TITLE
reject duplicate arguments in #[interrupt] and #[exception]

### DIFF
--- a/macros/src/syntax.rs
+++ b/macros/src/syntax.rs
@@ -937,6 +937,13 @@ fn parse_args(input: ParseStream<'_>, accept_capacity: bool) -> parse::Result<Ta
         let ident_s = ident.to_string();
         match &*ident_s {
             "capacity" if accept_capacity => {
+                if capacity.is_some() {
+                    return Err(parse::Error::new(
+                        ident.span(),
+                        "argument appears more than once",
+                    ));
+                }
+
                 // #lit
                 let lit: LitInt = content.parse()?;
 
@@ -958,6 +965,13 @@ fn parse_args(input: ParseStream<'_>, accept_capacity: bool) -> parse::Result<Ta
                 capacity = Some(value as u8);
             }
             "priority" => {
+                if priority.is_some() {
+                    return Err(parse::Error::new(
+                        ident.span(),
+                        "argument appears more than once",
+                    ));
+                }
+
                 // #lit
                 let lit: LitInt = content.parse()?;
 

--- a/tests/cfail/duplicate-args-2.rs
+++ b/tests/cfail/duplicate-args-2.rs
@@ -1,0 +1,24 @@
+#![no_main]
+#![no_std]
+
+extern crate lm3s6965;
+extern crate panic_halt;
+extern crate rtfm;
+
+use rtfm::app;
+
+#[app(device = lm3s6965)]
+const APP: () = {
+    #[init]
+    fn init() {}
+
+    #[task(
+        priority = 1,
+        priority = 2, //~ ERROR argument appears more than once
+    )]
+    fn foo() {}
+
+    extern "C" {
+        fn UART0();
+    }
+};

--- a/tests/cfail/duplicate-args.rs
+++ b/tests/cfail/duplicate-args.rs
@@ -1,0 +1,24 @@
+#![no_main]
+#![no_std]
+
+extern crate lm3s6965;
+extern crate panic_halt;
+extern crate rtfm;
+
+use rtfm::app;
+
+#[app(device = lm3s6965)]
+const APP: () = {
+    #[init]
+    fn init() {}
+
+    #[task(
+        capacity = 1,
+        capacity = 2, //~ ERROR argument appears more than once
+    )]
+    fn foo() {}
+
+    extern "C" {
+        fn UART0();
+    }
+};


### PR DESCRIPTION
This program was being accepted:

``` rust
#[task(
    capacity = 1,
    capacity = 2,
    priority = 1,
    priority = 2,
)]
fn foo() {}
```

now it will trigger a compiler error

r? @korken89 || @TeXitoi 