### PR TITLE
check task priority at compile time

### DIFF
--- a/book/en/src/by-example/resources.md
+++ b/book/en/src/by-example/resources.md
@@ -69,6 +69,13 @@ the critical section created by the lowest priority handler.
 $ cargo run --example lock
 {{#include ../../../../ci/expected/lock.run}}```
 
+One more note about priorities: choosing a priority higher than what the device
+supports (that is `1 << NVIC_PRIO_BITS`) will result in a compile error. Due to
+limitations in the language the error is currently far from helpful: it will say
+something along the lines of "evaluation of constant value failed" and the span
+of the error will *not* point out to the problematic interrupt value -- we are
+sorry about this!
+
 ## Late resources
 
 Unlike normal `static` variables, which need to be assigned an initial value

--- a/macros/src/syntax.rs
+++ b/macros/src/syntax.rs
@@ -1039,10 +1039,10 @@ fn parse_args(
                 }
 
                 let value = lit.value();
-                if value > u64::from(u8::MAX) {
+                if value > u64::from(u8::MAX) || value == 0 {
                     return Err(parse::Error::new(
                         lit.span(),
-                        "this literal must be in the range 0...255",
+                        "this literal must be in the range 1...255",
                     ));
                 }
 

--- a/tests/cfail/priority-too-high.rs
+++ b/tests/cfail/priority-too-high.rs
@@ -1,0 +1,22 @@
+#![no_main]
+#![no_std]
+
+extern crate lm3s6965;
+extern crate panic_halt;
+extern crate rtfm;
+
+use rtfm::app;
+
+#[app(device = lm3s6965)] //~ error evaluation of constant value failed
+const APP: () = {
+    #[init]
+    fn init() {}
+
+    // OK, this is the maximum priority supported by the device
+    #[interrupt(priority = 8)]
+    fn UART0() {}
+
+    // this value is too high!
+    #[interrupt(priority = 9)]
+    fn UART1() {}
+};

--- a/tests/cfail/priority-too-low.rs
+++ b/tests/cfail/priority-too-low.rs
@@ -1,0 +1,22 @@
+#![no_main]
+#![no_std]
+
+extern crate lm3s6965;
+extern crate panic_halt;
+extern crate rtfm;
+
+use rtfm::app;
+
+#[app(device = lm3s6965)]
+const APP: () = {
+    #[init]
+    fn init() {}
+
+    // OK, this is the minimum priority that tasks can have
+    #[interrupt(priority = 1)]
+    fn UART0() {}
+
+    // this value is too low!
+    #[interrupt(priority = 0)] //~ error this literal must be in the range 1...255
+    fn UART1() {}
+};


### PR DESCRIPTION
before we were checking the priority at runtime. The compile time error message
when the priority is too high is kind of awful though.