### PR TITLE
Enable the DWT unit before poking at its registers. (v0.4.x)

### DIFF
--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -507,7 +507,6 @@ fn post_init(ctxt: &Context, app: &App, analysis: &Analysis) -> proc_macro2::Tok
 
     // Enable cycle counter
     if cfg!(feature = "timer-queue") {
-        exprs.push(quote!(p.DCB.enable_trace()));
         exprs.push(quote!(p.DWT.enable_cycle_counter()));
     }
 
@@ -2024,6 +2023,8 @@ fn pre_init(ctxt: &Context, app: &App, analysis: &Analysis) -> proc_macro2::Toke
 
     // Set the cycle count to 0 and disable it while `init` executes
     if cfg!(feature = "timer-queue") {
+        // We need to explicitly enable the trace block to set CYCCNT.
+        exprs.push(quote!(p.DCB.enable_trace();));
         exprs.push(quote!(p.DWT.ctrl.modify(|r| r & !1);));
         exprs.push(quote!(p.DWT.cyccnt.write(0);));
     }


### PR DESCRIPTION
On cold boot, the DWT unit is off, which means our attempts to clear and
disable the cycle counter in pre-init don't work. This seems to result
in access to CYCCNT always returning 1073741824, which delays tasks
scheduled in init by that many cycles (~15s at 72 MHz).

Fixes #196.