### PR TITLE
Enable the DWT unit before poking at its registers.

### DIFF
--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -1204,6 +1204,8 @@ fn pre_init(app: &App, analysis: &Analysis) -> Vec<proc_macro2::TokenStream> {
 
     // Set the cycle count to 0 and disable it while `init` executes
     if cfg!(feature = "timer-queue") {
+        // We need to explicitly enable the trace block to set CYCCNT.
+        stmts.push(quote!(core.DCB.enable_trace();));
         stmts.push(quote!(core.DWT.ctrl.modify(|r| r & !1);));
         stmts.push(quote!(core.DWT.cyccnt.write(0);));
     }
@@ -1421,7 +1423,6 @@ fn post_init(app: &App, analysis: &Analysis) -> Vec<proc_macro2::TokenStream> {
 
     // enable the cycle counter
     if cfg!(feature = "timer-queue") {
-        stmts.push(quote!(core.DCB.enable_trace();));
         stmts.push(quote!(core.DWT.enable_cycle_counter();));
     }
 


### PR DESCRIPTION
On cold boot, the DWT unit is off, which means our attempts to clear and
disable the cycle counter in pre-init don't work. This seems to result
in access to CYCCNT always returning 1073741824, which delays tasks
scheduled in init by that many cycles (~15s at 72 MHz).

Fixes #196.